### PR TITLE
[FIX] Invalid path resolution for Windows

### DIFF
--- a/H4/armory-ts/src/publish.ts
+++ b/H4/armory-ts/src/publish.ts
@@ -2,6 +2,7 @@ import { SuiClient, SuiObjectChangeCreated, SuiObjectChangePublished, SuiTransac
 import { Keypair } from '@mysten/sui/cryptography';
 import { ADMIN_KEYPAIR } from './consts';
 import { Transaction } from '@mysten/sui/transactions';
+import path from 'path';
 
 import { execSync } from 'child_process';
 
@@ -16,7 +17,7 @@ export class PublishSingleton {
     public static async publish(client?: SuiClient, signer?: Keypair, packagePath?: string) {
         client ??= new SuiClient({ url: getFullnodeUrl('localnet') });
         signer ??= ADMIN_KEYPAIR;
-        packagePath ??= `${__dirname}/../../armory`;
+        packagePath ??= path.resolve(__dirname, '..', '..', 'armory');
         if (!PublishSingleton.instance) {
             const publishResp = await publishPackage(client, signer, packagePath);
             const packageId = findPublishedPackage(publishResp)?.packageId;

--- a/I2/publish/src/publish.ts
+++ b/I2/publish/src/publish.ts
@@ -2,6 +2,7 @@ import { SuiClient, SuiObjectChangeCreated, SuiObjectChangePublished, SuiTransac
 import { Keypair } from '@mysten/sui/cryptography';
 import { ADMIN_KEYPAIR } from './consts';
 import { Transaction } from '@mysten/sui/transactions';
+import path from 'path';
 
 import { execSync } from 'child_process';
 
@@ -21,7 +22,7 @@ export class PublishSingleton {
             keypair = ADMIN_KEYPAIR;
         }
         if (!packagePath) {
-            packagePath = `${__dirname}/../../fixed_supply`;
+            packagePath = path.resolve(__dirname, '..', '..', 'fixed_supply');
         }
         if (!PublishSingleton.instance) {
             const resp = await publishPackage(client, keypair, packagePath);

--- a/I4/marketplace/src/publish.ts
+++ b/I4/marketplace/src/publish.ts
@@ -2,6 +2,7 @@ import { SuiClient, SuiObjectChangeCreated, SuiObjectChangePublished, SuiTransac
 import { Keypair } from '@mysten/sui/cryptography';
 import { ADMIN_KEYPAIR } from './consts';
 import { Transaction } from '@mysten/sui/transactions';
+import path from 'path';
 
 import { execSync } from 'child_process';
 
@@ -16,7 +17,7 @@ export class PublishSingleton {
     public static async publish(client?: SuiClient, signer?: Keypair, packagePath?: string) {
         client ??= new SuiClient({ url: getFullnodeUrl('localnet') });
         signer ??= ADMIN_KEYPAIR;
-        packagePath ??= `${__dirname}/../../sword`;
+        packagePath ??= path.resolve(__dirname, '..', '..', 'sword');
         if (!PublishSingleton.instance) {
             const publishResp = await publishPackage(client, signer, packagePath);
             const packageId = findPublishedPackage(publishResp)?.packageId;

--- a/I5/marketplace/src/publish.ts
+++ b/I5/marketplace/src/publish.ts
@@ -2,6 +2,7 @@ import { SuiClient, SuiObjectChangeCreated, SuiObjectChangePublished, SuiTransac
 import { Keypair } from '@mysten/sui/cryptography';
 import { ADMIN_KEYPAIR } from './consts';
 import { Transaction } from '@mysten/sui/transactions';
+import path from 'path';
 
 import { execSync } from 'child_process';
 
@@ -26,8 +27,8 @@ export class PublishSingleton {
     }) {
         client ??= new SuiClient({ url: getFullnodeUrl('localnet') });
         signer ??= ADMIN_KEYPAIR;
-        packagePath ??= `${__dirname}/../../sword`;
-        rulesPath ??= `${__dirname}/../../kiosk_rules`;
+        packagePath ??= path.resolve(__dirname, '..', '..', 'sword');
+        rulesPath ??= path.resolve(__dirname, '..', '..', 'kiosk_rules');
         royalties ??= {
             basisPoints: 100, // 1%
             minRoyaltiesAmount: "10000000", // 0.01 SUI


### PR DESCRIPTION
### Background

On windows path separator is backslash (`\`). It was causing problems when trying to publish package for module i5. Fixing also other places where encountered.