### PR TITLE
Fix Silver coin create currency method

### DIFF
--- a/I1/silver/sources/silver.move
+++ b/I1/silver/sources/silver.move
@@ -25,8 +25,8 @@ fun create_silver_currency(
     coin::create_currency(
         otw,
         DECIMALS,
-        NAME,
         SYMBOL,
+        NAME,
         DESCRIPTION,
         option::some(url::new_unsafe_from_bytes(ICON_URL)),
         ctx,


### PR DESCRIPTION
NAME and SYMBOL arguments order in `coin::create_currency` method call.