### PR TITLE
Simplifying D1 start to focus on suiClient and getBalance

### DIFF
--- a/D1/README.md
+++ b/D1/README.md
@@ -2,87 +2,98 @@
 
 ### Sui Client Connection Setup with TypeScript SDK
 
-##### What you will learn in this module:
+### What you will learn in this module
 
-#### Default Client Setup
-- Using the Sui TypeScript SDK to connect to Sui networks
-- Default connection to MystenLabs public nodes
-- Available network options:
-  - Mainnet
-  - Testnet
-  - Devnet
-  - Localnet
-
-#### Custom Provider Configuration
-- Setting up a custom RPC provider
-- Configuring connection parameters
-- Handling custom endpoints
-- Using SuiHTTPTransport for custom request configuration
-- Example configuration with custom headers:
-  ```typescript
-  const transport = new SuiHTTPTransport({
-    url: 'https://your-custom-rpc-endpoint.com',
-    headers: {
-      'Authorization': 'Bearer your-api-key',
-      'Custom-Header': 'custom-value'
-    }
-  });
-  
-  const client = new SuiClient({ transport });
-  ```
-
-#### GraphQL Client Setup
-- Initializing the Sui GraphQL client
-- Configuring GraphQL-specific options
-- Understanding the differences between RPC and GraphQL clients
-- Example setup:
-  ```typescript
-  const graphqlClient = new SuiGraphQLClient({
-    url: 'https://your-graphql-endpoint.com'
-  });
-  ```
-
-#### Rate Limits and Best Practices
-- Understanding MystenLabs public node rate limits
-- Implementing rate limiting strategies
-- Best practices for production deployments
-- Considerations for:
-  - Request frequency
-  - Batch operations
-  - Error handling
-  - Retry mechanisms
-
-#### Client Usage Examples
-- Basic client operations
-- Error handling patterns
-- Connection management
-- Example patterns:
-  ```typescript
-  // Basic client usage
-  const client = new SuiClient();
-  
-  // Error handling
-  try {
-    const result = await client.getObject({ id: objectId });
-  } catch (error) {
-    // Handle specific error cases
-  }
-  ```
-
-#### Production Considerations
-- Connection pooling
-- Load balancing
-- Failover strategies
-- Monitoring and logging
-- Performance optimization
+- How to connect to a Sui network using the TypeScript SDK.
+- How to check the balance of an address.
+- How to use the faucet on Devnet/Testnet/Localnet to request SUI for gas.
+- How to write and run a simple Jest test that demonstrates these concepts.
 
 ---
+
+#### 1. Project Setup
+
+Before writing code, make sure your **`package.json`** includes the right dependencies:
+
+- **`@mysten/sui`** → TypeScript SDK for interacting with Sui.
+- **`dotenv`** → manage environment variables (optional, but useful for storing private keys).
+- **`ts-node`** → run TypeScript files directly.
+- **`typescript`** → compile TypeScript.
+- **`zod`** → runtime validation (often used for schemas).
+- **`jest`** → testing framework we’ll use to run our example.
+
+---
+
+#### 2. Initialize a SuiClient
+
+Use the SDK to connect to a specific network (Devnet in this example):
+
+```ts
+import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
+
+const suiClient = new SuiClient({ url: getFullnodeUrl("devnet") });
+```
+
+- `getFullnodeUrl("devnet")` gives the default Mysten-hosted Devnet endpoint.
+- Available options are `"mainnet"`, `"testnet"`, `"devnet"`, `"localnet"`.
+
+---
+
+#### 3. Get Balance
+
+To fetch the balance of an address:
+
+```ts
+const before = await suiClient.getBalance({ owner: MY_ADDRESS });
+```
+
+- Type of the response is `Promise<CoinBalance>`.
+- That’s why we need `before.totalBalance` to access the actual number.
+- In TypeScript, `?` marks an optional parameter — for `getBalance` only `owner` is required.
+
+---
+
+#### 4. Use the Faucet
+
+On Devnet/Testnet/Localnet you can get SUI for gas using the faucet API:
+
+```ts
+import { getFaucetHost, requestSuiFromFaucetV2 } from "@mysten/sui/faucet";
+
+await requestSuiFromFaucetV2({
+  host: getFaucetHost("devnet"),
+  recipient: MY_ADDRESS,
+});
+```
+
+---
+
+#### 5. Get Balance Again
+
+After calling the faucet, check the balance a second time:
+
+```ts
+const after = await suiClient.getBalance({ owner: MY_ADDRESS });
+```
+
+---
+
+#### 6. Assert the Result
+
+In a test, you can verify that the balance increased:
+
+```ts
+expect(Number(after.totalBalance)).toBeGreaterThan(Number(before.totalBalance));
+```
+
+---
+
 ### Useful Links
 
- - [Network Interactions with SuiClient
-](https://sdk.mystenlabs.com/typescript/sui-client)
- - [Sui Client Provider - React Dapp Kit](https://sdk.mystenlabs.com/dapp-kit/sui-client-provider)
- - [RPC Best Practices
-](https://docs.sui.io/references/sui-api/rpc-best-practices)
- - [Sui Full Node Configuration
-](https://docs.sui.io/guides/operator/sui-full-node)
+- [Network Interactions with SuiClient
+  ](https://sdk.mystenlabs.com/typescript/sui-client)
+- [Sui Client Provider - React Dapp Kit](https://sdk.mystenlabs.com/dapp-kit/sui-client-provider)
+- [RPC Best Practices
+  ](https://docs.sui.io/references/sui-api/rpc-best-practices)
+- [Sui Full Node Configuration
+  ](https://docs.sui.io/guides/operator/sui-full-node)

--- a/D1/ts/package-lock.json
+++ b/D1/ts/package-lock.json
@@ -9,13 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@mysten/sui": "^1.24.0",
+        "@mysten/sui": "^1.38.0",
         "dotenv": "^16.4.7",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.2",
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@jest/types": "^29.6.3",
         "@types/jest": "^29.5.14",
         "env-cmd": "^10.1.0",
         "jest": "^29.7.0",
@@ -23,9 +24,9 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.1.2.tgz",
-      "integrity": "sha512-N2NGsU5FLBhT8NZ+3l2YrzZSHITjNXNuDhC4iDiikv0IujaJ0Xc6xIxQZ/Ek3Cb+rgPjnLHYyJm11tInuJn+cw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
+      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -37,9 +38,9 @@
       }
     },
     "node_modules/@0no-co/graphqlsp": {
-      "version": "1.12.16",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.12.16.tgz",
-      "integrity": "sha512-B5pyYVH93Etv7xjT6IfB7QtMBdaaC07yjbhN6v8H7KgFStMkPvi+oWYBTibMFRMY89qwc9H8YixXg8SXDVgYWw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.0.tgz",
+      "integrity": "sha512-SReJAGmOeXrHGod+9Odqrz4s43liK0b2DFUetb/jmYvxFpWmeNfFYo0seCh0jz8vG3p1pnYMav0+Tm7XwWtOJw==",
       "license": "MIT",
       "dependencies": {
         "@gql.tada/internal": "^1.0.0",
@@ -585,9 +586,9 @@
       }
     },
     "node_modules/@gql.tada/cli-utils": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.6.3.tgz",
-      "integrity": "sha512-jFFSY8OxYeBxdKi58UzeMXG1tdm4FVjXa8WHIi66Gzu9JWtCE6mqom3a8xkmSw+mVaybFW5EN2WXf1WztJVNyQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.1.tgz",
+      "integrity": "sha512-wg5ysZNQxtNQm67T3laVWmZzLpGb7QfyYWZdaUD2r1OjDj5Bgftq7eQlplmH+hsdffjuUyhJw/b5XAjeE2mJtg==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphqlsp": "^1.12.13",
@@ -1046,43 +1047,54 @@
       }
     },
     "node_modules/@mysten/bcs": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.5.0.tgz",
-      "integrity": "sha512-v39dm5oNfKYMAf2CVI+L0OaJiG9RVXsjqPM4BwTKcHNCZOvr35IIewGtXtWXsI67SQU2TRq8lhQzeibdiC/CNg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.8.0.tgz",
+      "integrity": "sha512-bDoLN1nN+XPONsvpNyNyqYHndM3PKWS419GLeRnbLoWyNm4bnyD1X4luEpJLLDq400hBuXiCan4RWjofvyTUIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scure/base": "^1.2.4"
+        "@mysten/utils": "0.2.0",
+        "@scure/base": "^1.2.6"
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.24.0.tgz",
-      "integrity": "sha512-lmJJLM7eMrxM6Qpr6cdLr07UBXlxCM7SJjfcDO7NGrqZTx7/3TD2QhhRpDx0fS2tODxrNwQxCoHPApLVPjokIA==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.38.0.tgz",
+      "integrity": "sha512-tH6V4BJsYi5d97MOiLoOhyldrYxkm/cu8dYV52asqh1i88HrSVMbPAJ9sVoeWN2Ju+QsJ/Go4ldSjdCkaBCyJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "1.5.0",
-        "@noble/curves": "^1.4.2",
-        "@noble/hashes": "^1.4.0",
-        "@scure/base": "^1.2.4",
-        "@scure/bip32": "^1.4.0",
-        "@scure/bip39": "^1.3.0",
-        "gql.tada": "^1.8.2",
-        "graphql": "^16.9.0",
-        "poseidon-lite": "^0.2.0",
+        "@mysten/bcs": "1.8.0",
+        "@mysten/utils": "0.2.0",
+        "@noble/curves": "^1.9.4",
+        "@noble/hashes": "^1.8.0",
+        "@scure/base": "^1.2.6",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "gql.tada": "^1.8.13",
+        "graphql": "^16.11.0",
+        "poseidon-lite": "0.2.1",
         "valibot": "^0.36.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/@mysten/utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.2.0.tgz",
+      "integrity": "sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scure/base": "^1.2.6"
+      }
+    },
     "node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1092,9 +1104,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1104,36 +1116,36 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
-      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
-      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.8.1",
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.2"
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
-      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.4"
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2263,14 +2275,14 @@
       }
     },
     "node_modules/gql.tada": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.10.tgz",
-      "integrity": "sha512-FrvSxgz838FYVPgZHGOSgbpOjhR+yq44rCzww3oOPJYi0OvBJjAgCiP6LEokZIYND2fUTXzQAyLgcvgw1yNP5A==",
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.13.tgz",
+      "integrity": "sha512-fYoorairdPgxtE7Sf1X9/6bSN9Kt2+PN8KLg3hcF8972qFnawwUgs1OLVU8efZMHwL7EBHhhKBhrsGPlOs2lZQ==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
         "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/cli-utils": "1.6.3",
+        "@gql.tada/cli-utils": "1.7.1",
         "@gql.tada/internal": "1.0.8"
       },
       "bin": {
@@ -2289,9 +2301,9 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
-      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"

--- a/D1/ts/src/tests/suiClient.test.ts
+++ b/D1/ts/src/tests/suiClient.test.ts
@@ -1,216 +1,35 @@
-import {
-  CoinBalance,
-  getFullnodeUrl,
-  SuiClient,
-  SuiHTTPTransport,
-} from "@mysten/sui/client";
-import { SuiGraphQLClient } from "@mysten/sui/graphql";
-import { graphql } from "@mysten/sui/graphql/schemas/latest";
-import {
-  getFaucetHost,
-  requestSuiFromFaucetV1,
-  requestSuiFromFaucetV2,
-} from "@mysten/sui/faucet";
+import { CoinBalance, getFullnodeUrl, SuiClient } from "@mysten/sui/client";
+import { getFaucetHost, requestSuiFromFaucetV2 } from "@mysten/sui/faucet";
 import { MIST_PER_SUI } from "@mysten/sui/utils";
 
-xtest("Simple JSON RPC CLient - Devnet", async () => {
+const mistToSui = (b: CoinBalance) =>
+  Number(b.totalBalance) / Number(MIST_PER_SUI);
+
+test("SuiClient: getBalance + faucet (devnet)", async () => {
+  // 1) Address to fund (must be a valid Sui address)
   const MY_ADDRESS =
     "0xf38a463604d2db4582033a09db6f8d4b846b113b3cd0a7c4f0d4690b3fe6aa37";
 
-  // create a new SuiClient object pointing to the network you want to use
+  // 2) Initialize client (devnet)
   const suiClient = new SuiClient({ url: getFullnodeUrl("devnet") });
 
-  // Convert MIST to Sui
-  const balance = (balance: CoinBalance) => {
-    return Number.parseInt(balance.totalBalance) / Number(MIST_PER_SUI);
-  };
+  // 3) Balance BEFORE
 
-  // store the JSON representation for the SUI the address owns before using faucet
-  const suiBefore = await suiClient.getBalance({
-    owner: MY_ADDRESS,
-  });
-
+  // 4) Request from faucet (devnet)
   await requestSuiFromFaucetV2({
-    // use getFaucetHost to make sure you're using correct faucet address
-    // you can also just use the address (see Sui TypeScript SDK Quick Start for values)
     host: getFaucetHost("devnet"),
     recipient: MY_ADDRESS,
   });
 
-  // store the JSON representation for the SUI the address owns after using faucet
-  const suiAfter = await suiClient.getBalance({
-    owner: MY_ADDRESS,
-  });
+  // Wait 2 seconds before checking balance
+  await new Promise((r) => setTimeout(r, 2000));
 
-  expect(balance(suiAfter)).toBe(balance(suiBefore) + 10);
-});
+  // 5) Balance AFTER (no polling, just one check)
 
-xtest("Simple JSON RPC CLient - Localnet", async () => {
-  const MY_ADDRESS =
-    "0xf38a463604d2db4582033a09db6f8d4b846b113b3cd0a7c4f0d4690b3fe6aa37";
-
-  // create a new SuiClient object pointing to the network you want to use
-  const suiClient = new SuiClient({ url: getFullnodeUrl("localnet") });
-
-  // Convert MIST to Sui
-  const balance = (balance: CoinBalance) => {
-    return Number.parseInt(balance.totalBalance) / Number(MIST_PER_SUI);
-  };
-
-  // store the JSON representation for the SUI the address owns before using faucet
-  const suiBefore = await suiClient.getBalance({
-    owner: MY_ADDRESS,
-  });
-
-  let faucetResponse = await requestSuiFromFaucetV1({
-    // use getFaucetHost to make sure you're using correct faucet address
-    // you can also just use the address (see Sui TypeScript SDK Quick Start for values)
-    host: getFaucetHost("localnet"),
-    recipient: MY_ADDRESS,
-  });
-
-  console.log(faucetResponse);
-
-  // store the JSON representation for the SUI the address owns after using faucet
-  const suiAfter = await suiClient.getBalance({
-    owner: MY_ADDRESS,
-  });
-
-  expect(balance(suiAfter)).toBe(balance(suiBefore) + 1000);
-});
-
-xtest("Custom JSON RPC CLient - Localnet", async () => {
-  const MY_ADDRESS =
-    "0xf38a463604d2db4582033a09db6f8d4b846b113b3cd0a7c4f0d4690b3fe6aa38";
-
-  // create a new SuiClient object pointing to the network you want to use
-  const suiClient = new SuiClient({
-    transport: new SuiHTTPTransport({
-      url: "http://127.0.0.1:9000",
-      rpc: {
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: "Bearer my-secret-key",
-        },
-      },
-    }),
-  });
-
-  // Convert MIST to Sui
-  const balance = (balance: CoinBalance) => {
-    return Number.parseInt(balance.totalBalance) / Number(MIST_PER_SUI);
-  };
-
-  // store the JSON representation for the SUI the address owns before using faucet
-  const suiBefore = await suiClient.getBalance({
-    owner: MY_ADDRESS,
-  });
-
-  let faucetResponse = await requestSuiFromFaucetV1({
-    // use getFaucetHost to make sure you're using correct faucet address
-    // you can also just use the address (see Sui TypeScript SDK Quick Start for values)
-    host: getFaucetHost("localnet"),
-    recipient: MY_ADDRESS,
-  });
-
-  console.log(faucetResponse);
-
-  // store the JSON representation for the SUI the address owns after using faucet
-  const suiAfter = await suiClient.getBalance({
-    owner: MY_ADDRESS,
-  });
-
-  expect(balance(suiAfter)).toBe(balance(suiBefore) + 1000);
-});
-
-xtest("Simple GraphQL CLient - Testnet", async () => {
-  const MY_ADDRESS =
-    "0xf38a463604d2db4582033a09db6f8d4b846b113b3cd0a7c4f0d4690b3fe6aa39";
-
-  // create a new SuiClient object pointing to the network you want to use
-  const suiClient = new SuiGraphQLClient({
-    url: "https://sui-devnet.mystenlabs.com/graphql",
-  });
-
-  const balanceQuery = graphql(`
-    query {
-      address(address: "${MY_ADDRESS}") {
-        balance {
-          totalBalance
-        }
-      }
-    }
-  `);
-
-  // Convert MIST to Sui
-  const balance = (balance: CoinBalance) => {
-    return Number.parseInt(balance.totalBalance) / Number(MIST_PER_SUI);
-  };
-
-  // store the JSON representation for the SUI the address owns before using faucet
-  // @ts-ignore
-  const suiBefore = (
-    await suiClient.query({
-      query: balanceQuery,
-    })
-  ).data?.address.balance.totalBalance;
-
-  let faucetResponse = await requestSuiFromFaucetV2({
-    // use getFaucetHost to make sure you're using correct faucet address
-    // you can also just use the address (see Sui TypeScript SDK Quick Start for values)
-    host: getFaucetHost("devnet"),
-    recipient: MY_ADDRESS,
-  });
-
-  console.log(faucetResponse);
-
-  // store the JSON representation for the SUI the address owns after using faucet
-  // @ts-ignore
-  const suiAfter = (
-    await suiClient.query({
-      query: balanceQuery,
-    })
-  ).data?.address.balance.totalBalance;
-
-  // @ts-ignore
-  expect(balance(suiAfter)).toBe(balance(suiBefore) + 1000);
-});
-
-test("Simple JSON RPC CLient Limits - Testnet", async () => {
-  const MY_ADDRESS =
-    "0xf38a463604d2db4582033a09db6f8d4b846b113b3cd0a7c4f0d4690b3fe6a";
-
-  // create a new SuiClient object pointing to the network you want to use
-  // const suiClient = new SuiClient({ url: getFullnodeUrl("mainnet") });
-  const suiClient = new SuiClient({
-    transport: new SuiHTTPTransport({
-      url: "https://fullnode.testnet.sui.io:443",
-    }),
-  });
-
-  let error = undefined;
-
-  try {
-    // Create an array of promises for parallel execution
-    const promises = Array.from({ length: 800 }, (_, i) => {
-      const address = MY_ADDRESS.concat((i + 100).toString());
-      return suiClient.getOwnedObjects({
-        owner: address,
-      });
-    });
-
-    // Execute all promises in parallel
-    const results = await Promise.all(promises);
-
-    // Process results if needed
-    results.forEach((objects, index) => {
-      console.log(`Address ${index + 100}:`, objects);
-    });
-  } catch (e) {
-    error = e;
-  }
-
-  console.log(error);
-
-  expect(error).toBeDefined();
+  // 6) Assert it increased
+  expect(Number(after.totalBalance)).toBeGreaterThan(
+    Number(before.totalBalance)
+  );
+  console.log(`Before: ${mistToSui(before)} SUI`);
+  console.log(`After : ${mistToSui(after)} SUI`);
 });


### PR DESCRIPTION
**Simplified the D1 module lesson materials.**

- Replaced the previous advanced README with a version focused only on the basics:
- Removed sections on custom providers, GraphQL client, and production considerations to keep the lesson beginner-friendly.
- Added example code and clear step-by-step teaching notes.