### PR TITLE
Add templates for homogeneus issue and pull request creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Reporting a Problem/Bug
 about: Reporting a Problem/Bug
 title: ''
-labels: bug, Feedback
+labels: fix
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,8 +1,8 @@
 ---
 name: Requesting a Feature or Improvement
-about: "For feature requests. Please search for existing issues first. Also see CONTRIBUTING."
+about: "For feature requests. Please search for existing issues first."
 title: ''
-labels: Feedback, Feature
+labels: feat
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/pull_request_template.md
+++ b/.github/ISSUE_TEMPLATE/pull_request_template.md
@@ -11,7 +11,7 @@ ______
 For contributor use:
 
 - [ ] Targeted PR against `main` branch
-- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
+- [ ] Linked to Github issue with discussion
 - [ ] Updated relevant documentation 
 - [ ] Re-reviewed `Files changed` in the Github PR explorer
 - [ ] Added appropriate labels 


### PR DESCRIPTION
Merging this will make any fresh PR made in advance look like this:
_________________

Closes: #???

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 