### PR TITLE
feat(simulator): 3D robotics simulator playground for R1-R10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ build
 node_modules
 target
 
+# Next.js
+.next/
+dist/
+
 # claude
 CLAUDE.md
 .claude/

--- a/R1/hello-bittle/package.json
+++ b/R1/hello-bittle/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "start": "npx tsx src/index.ts",
-    "demo": "npx tsx src/demo.ts"
+    "demo": "npx tsx src/demo.ts",
+    "sim": "npx tsx src/sim.ts",
+    "sim:interactive": "npx tsx src/sim-interactive.ts"
   },
   "dependencies": {
     "dotenv": "^17.3.1",

--- a/R1/hello-bittle/src/sim-interactive.ts
+++ b/R1/hello-bittle/src/sim-interactive.ts
@@ -1,0 +1,69 @@
+/**
+ * R1 Interactive Simulator — Control the virtual Bittle in real-time
+ *
+ * Prerequisites:
+ *   1. Start the simulator: cd simulator && npm run dev
+ *   2. Run this: npx tsx src/sim-interactive.ts
+ */
+
+import readline from "readline";
+import { VirtualSerialPort } from "../../../simulator/lib/virtual-serial.js";
+import { COMMANDS } from "./commands.js";
+
+const port = new VirtualSerialPort();
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+port.on("open", () => {
+  console.log("");
+  console.log("=".repeat(50));
+  console.log("  R1: Interactive Robot Control (Simulator)");
+  console.log("=".repeat(50));
+  console.log("");
+  console.log("Available commands:");
+
+  const entries = Object.entries(COMMANDS);
+  for (const [name, cmd] of entries) {
+    console.log(`  ${name.padEnd(15)} → ${cmd.code}`);
+  }
+  console.log("");
+  console.log("Type a command name or raw serial code (e.g. 'sit' or 'ksit'):");
+  console.log("Type 'quit' to exit.\n");
+
+  port.on("data", (data: Buffer) => {
+    const msg = data.toString().trim();
+    if (msg) console.log(`  << ${msg}`);
+  });
+
+  rl.on("line", (input) => {
+    const trimmed = input.trim();
+    if (trimmed === "quit" || trimmed === "exit") {
+      port.close();
+      rl.close();
+      process.exit(0);
+    }
+
+    // Check if it's a command name
+    const cmd = COMMANDS[trimmed as keyof typeof COMMANDS];
+    if (cmd) {
+      console.log(`  >> ${cmd.code}`);
+      port.write(cmd.code + "\n");
+    } else if (trimmed.startsWith("k")) {
+      // Raw serial command
+      console.log(`  >> ${trimmed}`);
+      port.write(trimmed + "\n");
+    } else {
+      console.log(`  Unknown command. Try: ${Object.keys(COMMANDS).join(", ")}`);
+    }
+  });
+});
+
+port.on("error", (err: Error) => {
+  console.error("Connection failed. Is the simulator running?");
+  console.error("  Start it: cd simulator && npm run dev");
+  console.error(`  Error: ${err.message}`);
+  process.exit(1);
+});

--- a/R1/hello-bittle/src/sim.ts
+++ b/R1/hello-bittle/src/sim.ts
@@ -1,0 +1,74 @@
+/**
+ * R1 Simulator Mode — Hello Bittle without hardware
+ *
+ * Runs the same demo as demo.ts but connects to the SuiBotics simulator
+ * instead of a physical Petoi Bittle robot.
+ *
+ * Prerequisites:
+ *   1. Start the simulator: cd simulator && npm run dev
+ *   2. Run this: npx tsx src/sim.ts
+ */
+
+import { VirtualSerialPort } from "../../../simulator/lib/virtual-serial.js";
+import { COMMANDS } from "./commands.js";
+
+const port = new VirtualSerialPort();
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function sendCommand(
+  name: string,
+  duration: number
+): Promise<void> {
+  const cmd = COMMANDS[name as keyof typeof COMMANDS];
+  if (!cmd) {
+    console.log(`  Unknown command: ${name}`);
+    return;
+  }
+  process.stdout.write(`  Sending "${name}" (${cmd.code})... `);
+  port.write(cmd.code + "\n");
+  await wait(duration);
+  console.log("done");
+}
+
+port.on("open", async () => {
+  console.log("");
+  console.log("=".repeat(50));
+  console.log("  R1: Hello Bittle — Simulator Mode");
+  console.log("  Connected to Virtual Bittle");
+  console.log("=".repeat(50));
+  console.log("");
+
+  // Listen for responses
+  port.on("data", (data: Buffer) => {
+    const msg = data.toString().trim();
+    if (msg) console.log(`  Bittle says: ${msg}`);
+  });
+
+  // Run the demo sequence
+  console.log("Running demo sequence...\n");
+
+  await sendCommand("hi", 3000);
+  await sendCommand("sit", 2000);
+  await sendCommand("balance", 2000);
+  await sendCommand("walkForward", 4000);
+  await sendCommand("jump", 2000);
+  await sendCommand("pushUp", 5000);
+  await sendCommand("stretch", 3000);
+  await sendCommand("playDead", 3000);
+  await sendCommand("balance", 2000);
+
+  console.log("\nDemo complete!");
+  console.log("Try the interactive mode: npx tsx src/sim-interactive.ts\n");
+  port.close();
+  process.exit(0);
+});
+
+port.on("error", (err: Error) => {
+  console.error("Connection failed. Is the simulator running?");
+  console.error("  Start it: cd simulator && npm run dev");
+  console.error(`  Error: ${err.message}`);
+  process.exit(1);
+});

--- a/R4/processor/package.json
+++ b/R4/processor/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "npx tsx src/processor.ts",
     "dev": "npx tsx watch src/processor.ts",
+    "sim": "npx tsx src/sim.ts",
     "test-serial": "npx tsx src/test-serial.ts",
     "test-blockchain": "npx tsx src/test-blockchain.ts"
   },

--- a/R4/processor/src/sim.ts
+++ b/R4/processor/src/sim.ts
@@ -1,0 +1,94 @@
+/**
+ * R4 Simulator Mode — Blockchain Robot Processor
+ *
+ * Polls the Sui blockchain for queued actions (same as processor.ts)
+ * but sends commands to the SuiBotics simulator instead of physical hardware.
+ *
+ * Prerequisites:
+ *   1. Deploy the R2 contract and set up .env (PACKAGE_ADDRESS, QUEUE_ID, etc.)
+ *   2. Start the simulator: cd simulator && npm run dev
+ *   3. Run this: npx tsx src/sim.ts
+ */
+
+import { VirtualSerialPort } from "../../../simulator/lib/virtual-serial.js";
+import { readQueue, popAction } from "./blockchain.js";
+import { ACTION_TO_COMMAND } from "./commands.js";
+import { config } from "./config.js";
+
+const port = new VirtualSerialPort();
+let isRunning = true;
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function processLoop(): Promise<void> {
+  console.log("");
+  console.log("=".repeat(50));
+  console.log("  R4: Blockchain Robot Processor (Simulator)");
+  console.log("=".repeat(50));
+  console.log("");
+  console.log(`  Package:  ${config.packageAddress}`);
+  console.log(`  Queue:    ${config.queueId}`);
+  console.log(`  Polling:  every ${config.pollIntervalMs}ms`);
+  console.log(`  Robot:    Virtual Bittle (simulator)`);
+  console.log("");
+
+  while (isRunning) {
+    try {
+      const state = await readQueue();
+      const pending = state.actions?.length || 0;
+
+      if (pending > 0) {
+        const action = state.actions[0];
+        console.log(`  [Queue] ${pending} action(s) pending. Next: "${action.name}"`);
+
+        // Map action to serial command
+        const mapping = ACTION_TO_COMMAND[action.name];
+        if (mapping) {
+          console.log(`  [Robot] Executing ${mapping.code} (${mapping.duration}ms)...`);
+          port.write(mapping.code + "\n");
+          await wait(mapping.duration);
+          console.log(`  [Robot] Done.`);
+        } else {
+          console.log(`  [Robot] Unknown action "${action.name}", skipping.`);
+        }
+
+        // Pop from blockchain queue
+        await popAction();
+        console.log(`  [Chain] Action processed and removed from queue.\n`);
+      } else {
+        if (config.debug) console.log("  [Queue] Empty, waiting...");
+      }
+    } catch (err) {
+      console.error(`  [Error] ${(err as Error).message}`);
+    }
+
+    await wait(config.pollIntervalMs);
+  }
+}
+
+port.on("open", () => {
+  console.log("  Connected to Virtual Bittle simulator.");
+
+  port.on("data", (data: Buffer) => {
+    const msg = data.toString().trim();
+    if (msg && config.debug) console.log(`  [Serial] ${msg}`);
+  });
+
+  processLoop().catch(console.error);
+});
+
+port.on("error", (err: Error) => {
+  console.error("Connection failed. Is the simulator running?");
+  console.error("  Start it: cd simulator && npm run dev");
+  console.error(`  Error: ${err.message}`);
+  process.exit(1);
+});
+
+process.on("SIGINT", () => {
+  console.log("\n  Shutting down...");
+  isRunning = false;
+  port.close();
+  process.exit(0);
+});

--- a/R5/server/package.json
+++ b/R5/server/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "npx tsx src/server.ts",
-    "dev": "npx tsx watch src/server.ts"
+    "dev": "npx tsx watch src/server.ts",
+    "sim": "npx tsx src/sim.ts"
   },
   "dependencies": {
     "dotenv": "^16.6.1",

--- a/R5/server/src/sim.ts
+++ b/R5/server/src/sim.ts
@@ -1,0 +1,178 @@
+/**
+ * R5 Simulator Mode — Live Control (WebSocket + Virtual Serial)
+ *
+ * Runs the R5 WebSocket control server but connects to the SuiBotics
+ * simulator instead of a physical serial port.
+ *
+ * Prerequisites:
+ *   1. Start the simulator: cd simulator && npm run dev
+ *   2. Run this: npx tsx src/sim.ts
+ *   3. Open R5/public/index.html in browser (or http://localhost:8080)
+ */
+
+import { createServer } from "http";
+import { WebSocketServer, WebSocket } from "ws";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { VirtualSerialPort } from "../../../simulator/lib/virtual-serial.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORT = parseInt(process.env.PORT || "8080");
+const QUEUE_COMMANDS = process.env.QUEUE_COMMANDS !== "false";
+const MAX_QUEUE_SIZE = parseInt(process.env.MAX_QUEUE_SIZE || "10");
+
+// ── Virtual Robot Connection ──────────────────────
+const robot = new VirtualSerialPort();
+let robotBusy = false;
+let currentAction: string | null = null;
+
+const COMMANDS: Record<string, { code: string; duration: number }> = {
+  sit: { code: "ksit", duration: 2000 },
+  stand: { code: "kbalance", duration: 2000 },
+  forward: { code: "kwkF", duration: 4000 },
+  backward: { code: "kbk", duration: 4000 },
+  wave: { code: "khi", duration: 3000 },
+  jump: { code: "kjmp", duration: 2000 },
+  rest: { code: "krest", duration: 3000 },
+  pushup: { code: "kpu", duration: 5000 },
+  trot: { code: "ktrF", duration: 3000 },
+  stretch: { code: "kstr", duration: 3000 },
+  playdead: { code: "kpd", duration: 3000 },
+  standup: { code: "kup", duration: 2000 },
+};
+
+const commandQueue: string[] = [];
+
+// ── HTTP Server ───────────────────────────────────
+const server = createServer((req, res) => {
+  if (req.url === "/" || req.url === "/index.html") {
+    try {
+      const html = readFileSync(join(__dirname, "../public/index.html"), "utf-8");
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(html);
+    } catch {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(`<html><body><h1>R5 Server Running (Simulator Mode)</h1>
+        <p>Open the SuiBotics playground at <a href="http://localhost:3000">http://localhost:3000</a> to see the 3D robot.</p>
+        <p>Or use wscat: <code>wscat -c ws://localhost:${PORT}</code></p></body></html>`);
+    }
+  } else if (req.url === "/api/state") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ busy: robotBusy, currentAction, queueLength: commandQueue.length }));
+  } else if (req.url === "/api/commands") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(Object.keys(COMMANDS)));
+  } else {
+    res.writeHead(404);
+    res.end("Not found");
+  }
+});
+
+// ── WebSocket Server ──────────────────────────────
+const wss = new WebSocketServer({ server });
+const clients = new Set<WebSocket>();
+
+function broadcast(msg: object) {
+  const data = JSON.stringify(msg);
+  for (const client of clients) {
+    if (client.readyState === WebSocket.OPEN) client.send(data);
+  }
+}
+
+async function executeCommand(name: string): Promise<void> {
+  const cmd = COMMANDS[name];
+  if (!cmd) return;
+
+  robotBusy = true;
+  currentAction = name;
+  broadcast({ type: "action_started", action: name, duration: cmd.duration });
+
+  robot.write(cmd.code + "\n");
+  await new Promise((r) => setTimeout(r, cmd.duration));
+
+  robotBusy = false;
+  currentAction = null;
+  broadcast({ type: "action_completed", action: name });
+
+  // Process next in queue
+  if (commandQueue.length > 0) {
+    const next = commandQueue.shift()!;
+    broadcast({ type: "queue_update", queue: [...commandQueue], next });
+    executeCommand(next);
+  }
+}
+
+wss.on("connection", (ws) => {
+  clients.add(ws);
+  broadcast({ type: "client_count", count: clients.size });
+  ws.send(JSON.stringify({
+    type: "welcome",
+    commands: Object.keys(COMMANDS),
+    state: { busy: robotBusy, currentAction, queueLength: commandQueue.length },
+  }));
+
+  ws.on("message", (data) => {
+    try {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === "command" && msg.command) {
+        const name = msg.command.toLowerCase();
+        if (!COMMANDS[name]) {
+          ws.send(JSON.stringify({ type: "error", message: `Unknown command: ${name}` }));
+          return;
+        }
+
+        if (robotBusy) {
+          if (QUEUE_COMMANDS && commandQueue.length < MAX_QUEUE_SIZE) {
+            commandQueue.push(name);
+            broadcast({ type: "queue_update", queue: [...commandQueue] });
+          } else {
+            ws.send(JSON.stringify({ type: "error", message: "Robot busy, command dropped" }));
+          }
+          return;
+        }
+
+        executeCommand(name);
+      } else if (msg.type === "ping") {
+        ws.send(JSON.stringify({ type: "pong", timestamp: Date.now() }));
+      }
+    } catch { /* ignore */ }
+  });
+
+  ws.on("close", () => {
+    clients.delete(ws);
+    broadcast({ type: "client_count", count: clients.size });
+  });
+});
+
+// ── Start ─────────────────────────────────────────
+robot.on("open", () => {
+  console.log("");
+  console.log("=".repeat(50));
+  console.log("  R5: Live Control — Simulator Mode");
+  console.log("=".repeat(50));
+  console.log("");
+  console.log("  Connected to Virtual Bittle simulator.");
+
+  robot.on("data", (data: Buffer) => {
+    const msg = data.toString().trim();
+    if (msg) console.log(`  [Robot] ${msg}`);
+  });
+
+  server.listen(PORT, () => {
+    console.log(`  WebSocket server: ws://localhost:${PORT}`);
+    console.log(`  HTTP server:      http://localhost:${PORT}`);
+    console.log(`  Queue mode:       ${QUEUE_COMMANDS ? "enabled" : "disabled"}`);
+    console.log("");
+    console.log("  Open the playground at http://localhost:3000 to see the 3D robot,");
+    console.log("  or connect any WebSocket client to ws://localhost:" + PORT);
+    console.log("");
+  });
+});
+
+robot.on("error", (err: Error) => {
+  console.error("Failed to connect to simulator. Is it running?");
+  console.error("  Start it: cd simulator && npm run dev");
+  console.error(`  Error: ${err.message}`);
+  process.exit(1);
+});

--- a/R7/part-a-offchain/package.json
+++ b/R7/part-a-offchain/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "generate-keys": "npx tsx src/generate-keys.ts",
     "server": "npx tsx src/server.ts",
+    "sim": "npx tsx src/sim.ts",
     "client": "npx tsx src/client.ts",
     "demo": "npx tsx src/demo.ts"
   },

--- a/R7/part-a-offchain/src/sim.ts
+++ b/R7/part-a-offchain/src/sim.ts
@@ -1,0 +1,212 @@
+/**
+ * R7 Part A Simulator Mode — Authenticated Robot Control
+ *
+ * Runs the challenge-response auth server but connects to the SuiBotics
+ * simulator instead of a physical serial port.
+ *
+ * Prerequisites:
+ *   1. Generate keys: npx tsx src/generate-keys.ts
+ *   2. Start the simulator: cd simulator && npm run dev
+ *   3. Start this server: npx tsx src/sim.ts
+ *   4. Start the client: npx tsx src/client.ts
+ */
+
+import { createServer } from "http";
+import { WebSocketServer, WebSocket } from "ws";
+import { randomBytes } from "crypto";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import * as ed from "@noble/ed25519";
+import { VirtualSerialPort } from "../../../simulator/lib/virtual-serial.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORT = parseInt(process.env.PORT || "8080");
+
+// Allowed public keys (hex strings)
+const ALLOWED_KEYS = new Set(
+  (process.env.ALLOWED_PUBLIC_KEYS || "").split(",").filter(Boolean)
+);
+
+const COMMANDS: Record<string, { code: string; duration: number }> = {
+  sit: { code: "ksit", duration: 2000 },
+  stand: { code: "kbalance", duration: 2000 },
+  wave: { code: "khi", duration: 3000 },
+  walk: { code: "kwkF", duration: 4000 },
+  jump: { code: "kjmp", duration: 2000 },
+  rest: { code: "krest", duration: 3000 },
+  pushup: { code: "kpu", duration: 5000 },
+  trot: { code: "ktrF", duration: 3000 },
+};
+
+interface ClientState {
+  challenge: Buffer | null;
+  authenticated: boolean;
+  publicKey: string | null;
+}
+
+// ── Virtual Robot Connection ──────────────────────
+const robot = new VirtualSerialPort();
+let robotBusy = false;
+
+// ── HTTP + WebSocket Server ───────────────────────
+const httpServer = createServer((req, res) => {
+  if (req.url === "/" || req.url === "/index.html") {
+    try {
+      const html = readFileSync(join(__dirname, "../public/index.html"), "utf-8");
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(html);
+    } catch {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<h1>R7 Auth Server (Simulator)</h1>");
+    }
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const wss = new WebSocketServer({ server: httpServer });
+const clientStates = new Map<WebSocket, ClientState>();
+
+function send(ws: WebSocket, msg: object) {
+  if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(msg));
+}
+
+wss.on("connection", (ws) => {
+  clientStates.set(ws, { challenge: null, authenticated: false, publicKey: null });
+  console.log("  [Auth] New client connected");
+  send(ws, { type: "info", message: "Send auth_start with your public key to begin." });
+
+  ws.on("message", async (data) => {
+    try {
+      const msg = JSON.parse(data.toString());
+      const state = clientStates.get(ws)!;
+
+      switch (msg.type) {
+        case "auth_start": {
+          const pubKey = msg.publicKey;
+          if (!pubKey || typeof pubKey !== "string") {
+            send(ws, { type: "error", message: "Missing publicKey" });
+            return;
+          }
+
+          // Check whitelist (if configured)
+          if (ALLOWED_KEYS.size > 0 && !ALLOWED_KEYS.has(pubKey)) {
+            send(ws, { type: "error", message: "Public key not authorized" });
+            return;
+          }
+
+          // Generate random challenge
+          const challenge = randomBytes(32);
+          state.challenge = challenge;
+          state.publicKey = pubKey;
+          console.log(`  [Auth] Challenge sent to ${pubKey.slice(0, 8)}...`);
+          send(ws, { type: "auth_challenge", challenge: challenge.toString("hex") });
+          break;
+        }
+
+        case "auth_response": {
+          if (!state.challenge || !state.publicKey) {
+            send(ws, { type: "error", message: "No pending challenge" });
+            return;
+          }
+
+          const sig = Buffer.from(msg.signature, "hex");
+          const valid = await ed.verifyAsync(sig, state.challenge, state.publicKey);
+
+          if (valid) {
+            state.authenticated = true;
+            console.log(`  [Auth] Client ${state.publicKey.slice(0, 8)}... AUTHENTICATED`);
+            send(ws, {
+              type: "auth_success",
+              message: "Authentication successful!",
+              commands: Object.keys(COMMANDS),
+            });
+          } else {
+            console.log(`  [Auth] Client ${state.publicKey.slice(0, 8)}... FAILED`);
+            send(ws, { type: "auth_failed", message: "Invalid signature" });
+          }
+          break;
+        }
+
+        case "command": {
+          if (!state.authenticated) {
+            send(ws, { type: "error", message: "Not authenticated. Send auth_start first." });
+            return;
+          }
+
+          const cmdName = msg.command?.toLowerCase();
+          const cmd = COMMANDS[cmdName];
+          if (!cmd) {
+            send(ws, { type: "error", message: `Unknown command: ${cmdName}` });
+            return;
+          }
+
+          if (robotBusy) {
+            send(ws, { type: "error", message: "Robot busy" });
+            return;
+          }
+
+          robotBusy = true;
+          console.log(`  [Cmd] ${state.publicKey!.slice(0, 8)}... -> ${cmdName}`);
+          robot.write(cmd.code + "\n");
+          send(ws, { type: "action_started", action: cmdName, duration: cmd.duration });
+
+          setTimeout(() => {
+            robotBusy = false;
+            send(ws, { type: "action_completed", action: cmdName });
+          }, cmd.duration);
+          break;
+        }
+
+        default:
+          send(ws, { type: "error", message: `Unknown message type: ${msg.type}` });
+      }
+    } catch {
+      send(ws, { type: "error", message: "Invalid message format" });
+    }
+  });
+
+  ws.on("close", () => {
+    const state = clientStates.get(ws);
+    if (state?.publicKey) {
+      console.log(`  [Auth] Client ${state.publicKey.slice(0, 8)}... disconnected`);
+    }
+    clientStates.delete(ws);
+  });
+});
+
+// ── Start ─────────────────────────────────────────
+robot.on("open", () => {
+  console.log("");
+  console.log("=".repeat(50));
+  console.log("  R7: Secure the Channel — Simulator Mode");
+  console.log("=".repeat(50));
+  console.log("");
+  console.log("  Connected to Virtual Bittle simulator.");
+  if (ALLOWED_KEYS.size > 0) {
+    console.log(`  Whitelisted keys: ${ALLOWED_KEYS.size}`);
+  } else {
+    console.log("  No key whitelist (any key accepted).");
+  }
+
+  robot.on("data", (data: Buffer) => {
+    const msg = data.toString().trim();
+    if (msg) console.log(`  [Robot] ${msg}`);
+  });
+
+  httpServer.listen(PORT, () => {
+    console.log(`  Auth server: ws://localhost:${PORT}`);
+    console.log(`  Web UI:      http://localhost:${PORT}`);
+    console.log("");
+    console.log("  Waiting for clients to authenticate...\n");
+  });
+});
+
+robot.on("error", (err: Error) => {
+  console.error("Failed to connect to simulator. Is it running?");
+  console.error("  Start it: cd simulator && npm run dev");
+  console.error(`  Error: ${err.message}`);
+  process.exit(1);
+});

--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ Start with **[Module R1](#module-r1-hello-bittle--serial-basics)** or **[Module 
 
 A progressive, project-based series that teaches Sui development through building blockchain-controlled robotics — from a simple serial connection to a full rental platform with tokens, authentication, and multiplayer access. Most modules work in simulation mode; a physical [Petoi Bittle X](https://docs.petoi.com/) robot is optional.
 
+#### Simulator — No Hardware Required
+
+A 3D robot simulator (Next.js + Three.js) lets you run every R module without a physical robot. Start the playground and all hardware-dependent modules connect to it automatically:
+
+```bash
+cd simulator && npm install && npm run dev
+# Then in another terminal:
+cd R1/hello-bittle && pnpm sim          # serial simulation
+cd R4/processor   && pnpm sim          # blockchain → simulator bridge
+cd R5/server      && pnpm sim          # WebSocket + simulator
+cd R7/part-a-offchain && pnpm sim      # auth server + simulator
+```
+
+The simulator exposes a TCP serial bridge on port 8375 and a WebSocket UI at `http://localhost:3000` with command buttons, architecture diagrams, and full lesson content for each module. See [`simulator/README.md`](./simulator/README.md) for details.
+
 #### Fundamentals
 
 - [R1: Hello Bittle — Serial Basics](./R1/)

--- a/simulator/.env.example
+++ b/simulator/.env.example
@@ -1,0 +1,4 @@
+# On-chain contract addresses (Sui testnet)
+# Set these to enable on-chain robot actions via wallet signing
+NEXT_PUBLIC_SUI_PACKAGE_ID=0x27a3292a055a7904753a8c741579d9cdebc17010c8b65d3d1f00da43047962b7
+NEXT_PUBLIC_SUI_QUEUE_ID=0x83ba18609f73b99518b7aaa13ce4a17293c4d18c4e2bab38ce59c7dc0fef355c

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -1,0 +1,94 @@
+# SuiBotics Simulator
+
+A 3D robot simulator that replaces the Petoi Bittle X hardware for the R1–R10 module series. Built with Next.js, Three.js, and Tailwind CSS.
+
+## Quick Start
+
+```bash
+npm install
+npm run dev
+```
+
+Open `http://localhost:3000`. The simulator provides:
+
+- **3D robot viewport** — Virtual Bittle with animated poses, walk cycles, and mood-based eye colors
+- **Module browser** — All 10 lessons with rendered README content, architecture diagrams, and simulator instructions
+- **TCP serial bridge** on port 8375 — R modules connect here via `VirtualSerialPort`
+- **WebSocket** on `/ws` — Real-time state broadcasting to the browser UI
+- **REST API** — `GET /api/state`, `GET /api/commands`, `POST /api/command`, `GET /api/modules`, `GET /api/module/:id`
+
+## Using with R Modules
+
+Modules that need hardware (R1, R4, R5, R7) each have a `src/sim.ts` entry point:
+
+```bash
+# Terminal 1: keep the simulator running
+cd simulator && npm run dev
+
+# Terminal 2: run any hardware module in sim mode
+cd R1/hello-bittle && pnpm sim
+cd R4/processor   && pnpm sim
+cd R5/server      && pnpm sim
+cd R7/part-a-offchain && pnpm sim
+```
+
+Modules without hardware dependencies (R2, R3, R6, R8, R9, R10) run as-is. R10's server has a built-in `SIMULATE_ROBOT=true` flag.
+
+### Virtual Serial Adapter
+
+Each sim script imports `simulator/lib/virtual-serial.ts`, a zero-dependency TCP adapter using Node.js built-in `net.Socket`. It connects to `localhost:8375` and exposes the same API as the `serialport` npm package:
+
+```typescript
+import { VirtualSerialPort } from '../../simulator/lib/virtual-serial.js';
+const port = new VirtualSerialPort();
+port.on('open', () => port.write('ksit\n'));
+port.on('data', (buf) => console.log(buf.toString()));
+```
+
+## Architecture
+
+```
+Browser (Next.js + Three.js)
+       |
+   WebSocket /ws
+       |
+┌──────┴──────┐
+│  Custom     │
+│  Server     │── Next.js pages (/, /modules, /module/[id])
+│  (server.ts)│── REST API (/api/*)
+│             │── Robot state machine (src/lib/robot.ts)
+└──┬───────┬──┘
+   |       |
+WS /serial TCP :8375
+   |       |
+R modules connect here
+via VirtualSerialPort
+```
+
+## Command Support
+
+The robot state machine supports 17 commands plus 30+ aliases covering every naming convention used across R1–R10:
+
+| Serial | Alias Examples | Action |
+|--------|---------------|--------|
+| `ksit` | `sit`, `sitDown` | Sit down |
+| `kbalance` | `balance`, `stand`, `reset` | Stand balanced |
+| `khi` | `hi`, `wave`, `hello` | Wave hello |
+| `kwkF` | `wkF`, `forward`, `walk`, `walkForward`, `walk_forward` | Walk forward |
+| `kjmp` | `jmp`, `jump` | Jump |
+| `kpu` | `pu`, `pushUp`, `push_up` | Push-up |
+| `kpd` | `pd`, `playDead`, `play_dead` | Play dead |
+| `krest` | `rest`, `lie`, `sleep` | Rest |
+| `ktrF` | `trF`, `trot`, `trotForward` | Trot forward |
+| `kstr` | `str`, `stretch` | Stretch |
+| `kup` | `up`, `standUp`, `stand_up` | Stand tall |
+| `kbf` | `bf`, `backFlip`, `back_flip` | Backflip |
+
+## Tech Stack
+
+- **Next.js 14** (App Router, custom server)
+- **React 18** + TypeScript
+- **Tailwind CSS**
+- **Three.js** (procedural robot model, OrbitControls)
+- **WebSocket** (`ws` library)
+- **Node.js TCP** (serial bridge)

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -84,6 +84,50 @@ The robot state machine supports 17 commands plus 30+ aliases covering every nam
 | `kup` | `up`, `standUp`, `stand_up` | Stand tall |
 | `kbf` | `bf`, `backFlip`, `back_flip` | Backflip |
 
+## On-Chain Robot Actions
+
+Every control panel button (Sit, Stand, Up, Rest, Wave, Jump, Push-up, Stretch, Forward, Back, Left, Right) and keyboard shortcut (W/A/S/D/Space) triggers a real Sui testnet transaction when a wallet is connected.
+
+### How it works
+
+Each button click fires two independent paths:
+
+1. **Path A (WebSocket)** — robot animates immediately (~10ms)
+2. **Path B (On-chain)** — builds a PTB calling `robot_queue::add_action`, wallet signs, submits to Sui testnet (~2-3s)
+
+The robot never waits for the blockchain. If no wallet is connected, only Path A runs.
+
+### Contract
+
+Uses the R2 `action_queue::robot_queue` contract deployed on Sui testnet:
+
+| | Address |
+|---|---|
+| Package | `0x27a3292a055a7904753a8c741579d9cdebc17010c8b65d3d1f00da43047962b7` |
+| ActionQueue | `0x83ba18609f73b99518b7aaa13ce4a17293c4d18c4e2bab38ce59c7dc0fef355c` |
+
+The `add_action` function is permissionless — anyone with a Sui wallet can call it. Each call emits an `ActionAdded` event with the action name, sender address, and current queue length.
+
+### Wallet integration
+
+The simulator uses `@mysten/dapp-kit-react` for wallet connection:
+
+- Click **Connect wallet** in the navbar to open the wallet selection modal
+- Select any installed Sui wallet (Slush, Phantom, Suiet, etc.)
+- Once connected, every action button prompts a transaction signature
+- The terminal shows submission status and transaction digests
+- The control panel shows on-chain status cards (chain, queue length, total actions, pending txs)
+- Disconnect at any time — the simulator falls back to local-only mode
+
+### Configuration
+
+The testnet contract addresses are hardcoded as defaults. To use a different deployment:
+
+```bash
+cp .env.example .env.local
+# Edit the addresses in .env.local
+```
+
 ## Tech Stack
 
 - **Next.js 14** (App Router, custom server)
@@ -92,3 +136,5 @@ The robot state machine supports 17 commands plus 30+ aliases covering every nam
 - **Three.js** (procedural robot model, OrbitControls)
 - **WebSocket** (`ws` library)
 - **Node.js TCP** (serial bridge)
+- **@mysten/dapp-kit-react** + **@mysten/sui** (wallet connection, transaction signing)
+- **Sui Move** (R2 `action_queue::robot_queue` contract on testnet)

--- a/simulator/contracts/cookie/Move.toml
+++ b/simulator/contracts/cookie/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "cookie_token"
+edition = "2024"
+
+[dependencies]

--- a/simulator/contracts/cookie/sources/cookie.move
+++ b/simulator/contracts/cookie/sources/cookie.move
@@ -1,0 +1,170 @@
+/// COOKIE Token — 1 Billion Supply, Public Mint on Testnet
+///
+/// A token for the SuiBotics playground. Each COOKIE costs 1 robot action.
+/// Anyone can mint from the public faucet (rate-limited per user per day).
+///
+/// Supply:     1,000,000,000 COOKIE (1B)
+/// Decimals:   0 (whole tokens only)
+/// Faucet:     100 per request, 1000 per user per day
+#[allow(deprecated_usage)]
+module cookie_token::cookie;
+
+use sui::coin::{Self, Coin, TreasuryCap};
+use sui::table::{Self, Table};
+use sui::clock::Clock;
+use sui::event;
+
+// ── Constants ────────────────────────────────────────────────
+
+const MAX_SUPPLY: u64 = 1_000_000_000;
+const FAUCET_PER_REQUEST: u64 = 100;
+const FAUCET_PER_DAY: u64 = 1_000;
+const DAY_MS: u64 = 86_400_000;
+
+// ── Errors ───────────────────────────────────────────────────
+
+const ESupplyExceeded: u64 = 0;
+const EAmountTooLarge: u64 = 1;
+const EDailyLimitReached: u64 = 2;
+const EAmountZero: u64 = 3;
+
+// ── OTW ──────────────────────────────────────────────────────
+
+public struct COOKIE has drop {}
+
+// ── Faucet (shared object) ───────────────────────────────────
+
+public struct CookieFaucet has key {
+    id: UID,
+    treasury_cap: TreasuryCap<COOKIE>,
+    max_supply: u64,
+    per_request: u64,
+    per_day: u64,
+    records: Table<address, MintRecord>,
+}
+
+public struct MintRecord has store, drop {
+    amount_today: u64,
+    day_start: u64,
+}
+
+// ── Events ───────────────────────────────────────────────────
+
+public struct FaucetCreated has copy, drop {
+    faucet_id: address,
+    max_supply: u64,
+}
+
+public struct TokensMinted has copy, drop {
+    recipient: address,
+    amount: u64,
+    total_supply: u64,
+}
+
+// ── Init ─────────────────────────────────────────────────────
+
+fun init(otw: COOKIE, ctx: &mut TxContext) {
+    let (treasury_cap, metadata) = coin::create_currency(
+        otw,
+        0,
+        b"COOKIE",
+        b"SuiBotics Cookie",
+        b"Robot action token for the SuiBotics playground. 1 COOKIE = 1 robot action. 1B max supply, public faucet on testnet.",
+        option::none(),
+        ctx,
+    );
+
+    transfer::public_freeze_object(metadata);
+
+    let faucet = CookieFaucet {
+        id: object::new(ctx),
+        treasury_cap,
+        max_supply: MAX_SUPPLY,
+        per_request: FAUCET_PER_REQUEST,
+        per_day: FAUCET_PER_DAY,
+        records: table::new(ctx),
+    };
+
+    event::emit(FaucetCreated {
+        faucet_id: object::id_address(&faucet),
+        max_supply: MAX_SUPPLY,
+    });
+
+    transfer::share_object(faucet);
+}
+
+// ── Public mint (faucet) ─────────────────────────────────────
+
+/// Anyone can call this to mint COOKIE tokens.
+/// Rate-limited: max 100 per request, 1000 per user per day.
+public fun mint(
+    faucet: &mut CookieFaucet,
+    amount: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    assert!(amount > 0, EAmountZero);
+    assert!(amount <= faucet.per_request, EAmountTooLarge);
+
+    let current_supply = faucet.treasury_cap.total_supply();
+    assert!(current_supply + amount <= faucet.max_supply, ESupplyExceeded);
+
+    let sender = ctx.sender();
+    let now = clock.timestamp_ms();
+
+    // Check / reset daily limit
+    if (faucet.records.contains(sender)) {
+        let record = &mut faucet.records[sender];
+        if (now - record.day_start >= DAY_MS) {
+            record.amount_today = 0;
+            record.day_start = now;
+        };
+        assert!(record.amount_today + amount <= faucet.per_day, EDailyLimitReached);
+        record.amount_today = record.amount_today + amount;
+    } else {
+        faucet.records.add(sender, MintRecord {
+            amount_today: amount,
+            day_start: now,
+        });
+    };
+
+    faucet.treasury_cap.mint_and_transfer(amount, sender, ctx);
+
+    event::emit(TokensMinted {
+        recipient: sender,
+        amount,
+        total_supply: faucet.treasury_cap.total_supply(),
+    });
+}
+
+// ── Burn ─────────────────────────────────────────────────────
+
+/// Anyone can burn their own COOKIE tokens.
+public fun burn(
+    faucet: &mut CookieFaucet,
+    coin: Coin<COOKIE>,
+) {
+    faucet.treasury_cap.burn(coin);
+}
+
+// ── View functions ───────────────────────────────────────────
+
+public fun total_supply(faucet: &CookieFaucet): u64 {
+    faucet.treasury_cap.total_supply()
+}
+
+public fun max_supply(faucet: &CookieFaucet): u64 {
+    faucet.max_supply
+}
+
+public fun remaining_supply(faucet: &CookieFaucet): u64 {
+    faucet.max_supply - faucet.treasury_cap.total_supply()
+}
+
+public fun per_request_limit(faucet: &CookieFaucet): u64 {
+    faucet.per_request
+}
+
+public fun per_day_limit(faucet: &CookieFaucet): u64 {
+    faucet.per_day
+}

--- a/simulator/lib/virtual-serial.ts
+++ b/simulator/lib/virtual-serial.ts
@@ -1,0 +1,64 @@
+/**
+ * VirtualSerialPort — Zero-dependency drop-in replacement for `serialport`.
+ *
+ * Connects to the SuiBotics simulator's TCP serial bridge (default port 8375).
+ * Uses only Node.js built-in `net` module — no npm packages needed.
+ *
+ * Usage in any R module:
+ *   import { VirtualSerialPort as SerialPort } from "../../simulator/lib/virtual-serial.js";
+ *   const port = new SerialPort();
+ *   port.on("open", () => port.write("ksit\n"));
+ *   port.on("data", (buf) => console.log(buf.toString()));
+ */
+
+import { Socket } from "net";
+import { EventEmitter } from "events";
+
+const SIM_HOST = process.env.SIM_HOST || "localhost";
+const SIM_PORT = parseInt(process.env.SIM_PORT || "8375");
+
+export class VirtualSerialPort extends EventEmitter {
+  private socket: Socket;
+  isOpen = false;
+
+  constructor(_opts?: Record<string, unknown>) {
+    super();
+    this.socket = new Socket();
+
+    this.socket.connect(SIM_PORT, SIM_HOST, () => {
+      this.isOpen = true;
+      this.emit("open");
+    });
+
+    this.socket.on("data", (data: Buffer) => {
+      this.emit("data", data);
+    });
+
+    this.socket.on("error", (err: Error) => {
+      this.emit("error", err);
+    });
+
+    this.socket.on("close", () => {
+      this.isOpen = false;
+      this.emit("close");
+    });
+  }
+
+  write(data: string | Buffer, callback?: (err?: Error | null) => void): boolean {
+    if (!this.isOpen) {
+      callback?.(new Error("Port is not open"));
+      return false;
+    }
+    this.socket.write(data.toString());
+    callback?.(null);
+    return true;
+  }
+
+  close(callback?: (err?: Error | null) => void): void {
+    this.socket.end();
+    this.isOpen = false;
+    callback?.(null);
+  }
+}
+
+export { VirtualSerialPort as SerialPort };

--- a/simulator/next.config.mjs
+++ b/simulator/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const config = {
+  reactStrictMode: false,
+  transpilePackages: ['three', '@react-three/fiber', '@react-three/drei'],
+};
+
+export default config;

--- a/simulator/next.config.mjs
+++ b/simulator/next.config.mjs
@@ -2,6 +2,10 @@
 const config = {
   reactStrictMode: false,
   transpilePackages: ['three', '@react-three/fiber', '@react-three/drei'],
+  webpack: (config) => {
+    config.experiments = { ...config.experiments, asyncWebAssembly: true };
+    return config;
+  },
 };
 
 export default config;

--- a/simulator/package.json
+++ b/simulator/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "suibotics-simulator",
+  "version": "2.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx server.ts",
+    "build": "next build",
+    "start": "NODE_ENV=production tsx server.ts"
+  },
+  "dependencies": {
+    "@mysten/dapp-kit-core": "^1.2.0",
+    "@mysten/dapp-kit-react": "^2.0.1",
+    "@mysten/sui": "^2.8.0",
+    "@react-three/drei": "^9.114.3",
+    "@react-three/fiber": "^8.17.10",
+    "marked": "^15.0.4",
+    "next": "^14.2.18",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.170.0",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@types/three": "^0.170.0",
+    "@types/ws": "^8.5.13",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.16",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/simulator/package.json
+++ b/simulator/package.json
@@ -9,6 +9,7 @@
     "start": "NODE_ENV=production tsx server.ts"
   },
   "dependencies": {
+    "@dimforge/rapier3d-compat": "^0.19.3",
     "@mysten/dapp-kit-core": "^1.2.0",
     "@mysten/dapp-kit-react": "^2.0.1",
     "@mysten/sui": "^2.8.0",

--- a/simulator/postcss.config.cjs
+++ b/simulator/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/simulator/server.ts
+++ b/simulator/server.ts
@@ -1,0 +1,429 @@
+/**
+ * SuiBotics Simulator — Custom Next.js Server
+ *
+ * Creates an HTTP server with:
+ *  - Next.js request handler (pages + app router)
+ *  - WebSocket server on /ws (UI state broadcasts) and /serial (virtual serial bridge)
+ *  - TCP serial bridge on port 8375 (for VirtualSerialPort connections)
+ *  - REST API routes for robot state, commands, and module metadata
+ */
+
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { parse } from 'node:url';
+import { createServer as createTcpServer, Socket } from 'node:net';
+import { readFile } from 'node:fs/promises';
+import { dirname, extname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import next from 'next';
+import { WebSocketServer, WebSocket } from 'ws';
+
+// The robot state machine
+import { VirtualBittle } from './src/lib/robot.js';
+
+// Module metadata
+import { MODULES, MODULE_CONCEPTS } from './src/lib/modules.js';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const dev = process.env.NODE_ENV !== 'production';
+const hostname = 'localhost';
+const HTTP_PORT = parseInt(process.env.PORT || '3000', 10);
+const TCP_PORT = parseInt(process.env.TCP_PORT || '8375', 10);
+
+// Project root is one level up from simulator/
+const PROJECT_ROOT = join(__dirname, '..');
+const ROBOT_ASSET_ROOT = join(PROJECT_ROOT, 'robot-dog-unitree-go1');
+
+// ---------------------------------------------------------------------------
+// Next.js app
+// ---------------------------------------------------------------------------
+
+const app = next({ dev, hostname, port: HTTP_PORT });
+const handle = app.getRequestHandler();
+
+// ---------------------------------------------------------------------------
+// Robot instance
+// ---------------------------------------------------------------------------
+
+const robot = new VirtualBittle();
+
+// ---------------------------------------------------------------------------
+// Helper: read a module's README.md
+// ---------------------------------------------------------------------------
+
+async function readModuleReadme(moduleId: string): Promise<string | null> {
+  // Strip the 'R' prefix if present to get the number, then reconstruct
+  const readmePath = join(PROJECT_ROOT, moduleId, 'README.md');
+  try {
+    return await readFile(readmePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: JSON response
+// ---------------------------------------------------------------------------
+
+function jsonResponse(res: ServerResponse, data: unknown, status = 200) {
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
+  res.end(JSON.stringify(data));
+}
+
+function getContentType(pathname: string): string {
+  const extension = extname(pathname).toLowerCase();
+
+  if (extension === '.glb') {
+    return 'model/gltf-binary';
+  }
+  if (extension === '.png') {
+    return 'image/png';
+  }
+  if (extension === '.jpg' || extension === '.jpeg') {
+    return 'image/jpeg';
+  }
+  return 'application/octet-stream';
+}
+
+// ---------------------------------------------------------------------------
+// Helper: read request body
+// ---------------------------------------------------------------------------
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', (chunk: Buffer) => {
+      body += chunk.toString();
+    });
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+app.prepare().then(() => {
+  // -------------------------------------------------------------------------
+  // HTTP server
+  // -------------------------------------------------------------------------
+
+  const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const parsedUrl = parse(req.url || '/', true);
+    const { pathname } = parsedUrl;
+
+    // CORS preflight
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      });
+      res.end();
+      return;
+    }
+
+    try {
+      if (pathname?.startsWith('/robot-dog-unitree-go1/') && (req.method === 'GET' || req.method === 'HEAD')) {
+        const assetPath = resolve(PROJECT_ROOT, pathname.slice(1));
+
+        if (!assetPath.startsWith(ROBOT_ASSET_ROOT)) {
+          res.writeHead(403);
+          res.end('Forbidden');
+          return;
+        }
+
+        try {
+          const file = await readFile(assetPath);
+          res.writeHead(200, {
+            'Content-Type': getContentType(assetPath),
+            'Cache-Control': dev ? 'no-store' : 'public, max-age=31536000, immutable',
+          });
+          res.end(req.method === 'HEAD' ? undefined : file);
+          return;
+        } catch {
+          res.writeHead(404);
+          res.end('Not found');
+          return;
+        }
+      }
+
+      // -------------------------------------------------------------------
+      // REST API routes (handled before Next.js)
+      // -------------------------------------------------------------------
+
+      // GET /api/state — current robot state
+      if (pathname === '/api/state' && req.method === 'GET') {
+        jsonResponse(res, robot.getState());
+        return;
+      }
+
+      // GET /api/commands — available commands
+      if (pathname === '/api/commands' && req.method === 'GET') {
+        jsonResponse(res, VirtualBittle.getCommands());
+        return;
+      }
+
+      // POST /api/command — execute a command
+      if (pathname === '/api/command' && req.method === 'POST') {
+        const body = await readBody(req);
+        let command: string;
+        try {
+          const parsed = JSON.parse(body);
+          command = parsed.command;
+        } catch {
+          jsonResponse(res, { error: 'Invalid JSON body. Expected { "command": "ksit" }' }, 400);
+          return;
+        }
+
+        if (!command) {
+          jsonResponse(res, { error: 'Missing "command" field' }, 400);
+          return;
+        }
+
+        const result = robot.processCommand(command);
+        jsonResponse(res, { result, state: robot.getState() });
+        return;
+      }
+
+      // GET /api/modules — list all modules
+      if (pathname === '/api/modules' && req.method === 'GET') {
+        const modulesWithConcepts = MODULES.map((m) => ({
+          ...m,
+          concepts: MODULE_CONCEPTS[m.id] || [],
+        }));
+        jsonResponse(res, modulesWithConcepts);
+        return;
+      }
+
+      // GET /api/module/:id — single module with README
+      const moduleMatch = pathname?.match(/^\/api\/module\/([A-Za-z0-9]+)$/);
+      if (moduleMatch && req.method === 'GET') {
+        const moduleId = moduleMatch[1].toUpperCase();
+        const mod = MODULES.find((m) => m.id === moduleId);
+
+        if (!mod) {
+          jsonResponse(res, { error: `Module "${moduleId}" not found` }, 404);
+          return;
+        }
+
+        const readme = await readModuleReadme(moduleId);
+        jsonResponse(res, {
+          ...mod,
+          concepts: MODULE_CONCEPTS[mod.id] || [],
+          readme: readme || undefined,
+        });
+        return;
+      }
+
+      // -------------------------------------------------------------------
+      // Everything else → Next.js
+      // -------------------------------------------------------------------
+      await handle(req, res, parsedUrl);
+    } catch (err) {
+      console.error('Request error:', err);
+      jsonResponse(res, { error: 'Internal server error' }, 500);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // WebSocket server — /ws (UI state broadcasts)
+  // -------------------------------------------------------------------------
+
+  const wssUI = new WebSocketServer({ noServer: true });
+  const uiClients = new Set<WebSocket>();
+
+  wssUI.on('connection', (ws: WebSocket) => {
+    uiClients.add(ws);
+    console.log(`[WS /ws] Client connected (${uiClients.size} total)`);
+
+    // Send current state immediately
+    ws.send(JSON.stringify({ type: 'state', data: robot.getState() }));
+
+    ws.on('message', (data: Buffer) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        if (msg.type === 'command' && msg.command) {
+          const result = robot.processCommand(msg.command);
+          ws.send(JSON.stringify({ type: 'command_ack', result }));
+          return;
+        }
+
+        if (msg.type === 'action' && msg.action) {
+          const result = robot.executeAction(String(msg.action));
+          ws.send(JSON.stringify({ type: 'command_ack', result }));
+        }
+      } catch {
+        // Ignore malformed messages
+      }
+    });
+
+    ws.on('close', () => {
+      uiClients.delete(ws);
+      console.log(`[WS /ws] Client disconnected (${uiClients.size} total)`);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // WebSocket server — /serial (virtual serial bridge)
+  // -------------------------------------------------------------------------
+
+  const wssSerial = new WebSocketServer({ noServer: true });
+  const serialClients = new Set<WebSocket>();
+
+  wssSerial.on('connection', (ws: WebSocket) => {
+    serialClients.add(ws);
+    console.log(`[WS /serial] Serial client connected (${serialClients.size} total)`);
+
+    ws.on('message', (data: Buffer) => {
+      const cmd = data.toString().trim();
+      if (cmd) {
+        const result = robot.processCommand(cmd);
+        // Reply like a real Bittle: echo back the result
+        ws.send(result + '\n');
+      }
+    });
+
+    ws.on('close', () => {
+      serialClients.delete(ws);
+      console.log(`[WS /serial] Serial client disconnected (${serialClients.size} total)`);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // HTTP upgrade handler — route to correct WebSocket server
+  // -------------------------------------------------------------------------
+
+  server.on('upgrade', (req, socket, head) => {
+    const { pathname } = parse(req.url || '/');
+
+    if (pathname === '/ws') {
+      wssUI.handleUpgrade(req, socket, head, (ws) => {
+        wssUI.emit('connection', ws, req);
+      });
+    } else if (pathname === '/serial') {
+      wssSerial.handleUpgrade(req, socket, head, (ws) => {
+        wssSerial.emit('connection', ws, req);
+      });
+    } else {
+      socket.destroy();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Robot state change → broadcast to all UI clients
+  // -------------------------------------------------------------------------
+
+  robot.onStateChange((state, event) => {
+    const msg = JSON.stringify({ type: 'state', data: state, event });
+    for (const client of uiClients) {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(msg);
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // TCP serial bridge (port 8375)
+  // -------------------------------------------------------------------------
+
+  const tcpClients = new Set<Socket>();
+
+  const tcpServer = createTcpServer((socket: Socket) => {
+    tcpClients.add(socket);
+    const addr = `${socket.remoteAddress}:${socket.remotePort}`;
+    console.log(`[TCP :${TCP_PORT}] Serial client connected from ${addr} (${tcpClients.size} total)`);
+
+    let buffer = '';
+
+    socket.on('data', (data: Buffer) => {
+      buffer += data.toString();
+
+      // Process complete lines (commands terminated by \n)
+      let newlineIdx: number;
+      while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+        const cmd = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+
+        if (cmd) {
+          const result = robot.processCommand(cmd);
+          socket.write(result + '\n');
+        }
+      }
+    });
+
+    socket.on('close', () => {
+      tcpClients.delete(socket);
+      console.log(`[TCP :${TCP_PORT}] Serial client disconnected (${tcpClients.size} total)`);
+    });
+
+    socket.on('error', (err: Error) => {
+      console.error(`[TCP :${TCP_PORT}] Socket error:`, err.message);
+      tcpClients.delete(socket);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Start listening
+  // -------------------------------------------------------------------------
+
+  server.listen(HTTP_PORT, () => {
+    printBanner();
+  });
+
+  tcpServer.listen(TCP_PORT, () => {
+    console.log(`  TCP serial bridge listening on port ${TCP_PORT}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Startup banner
+// ---------------------------------------------------------------------------
+
+function printBanner() {
+  const reset = '\x1b[0m';
+  const bold = '\x1b[1m';
+  const dim = '\x1b[2m';
+  const green = '\x1b[32m';
+  const cyan = '\x1b[36m';
+  const yellow = '\x1b[33m';
+  const magenta = '\x1b[35m';
+
+  console.log('');
+  console.log(`${bold}${green}  ╔══════════════════════════════════════════════════╗${reset}`);
+  console.log(`${bold}${green}  ║                                                  ║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${bold}${cyan}SuiBotics Simulator v2.0${reset}                       ${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${dim}Virtual Bittle Robot + Next.js UI${reset}              ${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║                                                  ║${reset}`);
+  console.log(`${bold}${green}  ╠══════════════════════════════════════════════════╣${reset}`);
+  console.log(`${bold}${green}  ║                                                  ║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${bold}Web UI:${reset}        ${cyan}http://localhost:${HTTP_PORT}${reset}${' '.repeat(Math.max(0, 14 - String(HTTP_PORT).length))}${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${bold}WebSocket:${reset}     ${yellow}ws://localhost:${HTTP_PORT}/ws${reset}${' '.repeat(Math.max(0, 11 - String(HTTP_PORT).length))}${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${bold}Serial WS:${reset}     ${yellow}ws://localhost:${HTTP_PORT}/serial${reset}${' '.repeat(Math.max(0, 7 - String(HTTP_PORT).length))}${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${bold}TCP Serial:${reset}    ${magenta}localhost:${TCP_PORT}${reset}${' '.repeat(Math.max(0, 19 - String(TCP_PORT).length))}${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║                                                  ║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${bold}REST API:${reset}                                     ${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${dim}GET  /api/state${reset}      Robot state               ${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${dim}GET  /api/commands${reset}   Available commands         ${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${dim}POST /api/command${reset}    Execute command            ${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${dim}GET  /api/modules${reset}    Module list                ${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║${reset}   ${dim}GET  /api/module/:id${reset}  Module detail + README    ${bold}${green}║${reset}`);
+  console.log(`${bold}${green}  ║                                                  ║${reset}`);
+  console.log(`${bold}${green}  ╚══════════════════════════════════════════════════╝${reset}`);
+  console.log('');
+  console.log(`  ${dim}Mode: ${dev ? 'development' : 'production'}${reset}`);
+  console.log(`  ${dim}Modules: ${MODULES.length} available${reset}`);
+  console.log('');
+}

--- a/simulator/server.ts
+++ b/simulator/server.ts
@@ -245,16 +245,31 @@ app.prepare().then(() => {
   const wssUI = new WebSocketServer({ noServer: true });
   const uiClients = new Set<WebSocket>();
 
+  function broadcastClientCount() {
+    const msg = JSON.stringify({ type: 'clients_update', count: uiClients.size });
+    for (const c of uiClients) {
+      if (c.readyState === WebSocket.OPEN) c.send(msg);
+    }
+  }
+
   wssUI.on('connection', (ws: WebSocket) => {
     uiClients.add(ws);
     console.log(`[WS /ws] Client connected (${uiClients.size} total)`);
 
     // Send current state immediately
     ws.send(JSON.stringify({ type: 'state', data: robot.getState() }));
+    broadcastClientCount();
 
     ws.on('message', (data: Buffer) => {
       try {
         const msg = JSON.parse(data.toString());
+
+        // Ping/pong for latency measurement (R5)
+        if (msg.type === 'ping') {
+          ws.send(JSON.stringify({ type: 'pong', ts: msg.ts }));
+          return;
+        }
+
         if (msg.type === 'command' && msg.command) {
           const result = robot.processCommand(msg.command);
           ws.send(JSON.stringify({ type: 'command_ack', result }));
@@ -273,6 +288,7 @@ app.prepare().then(() => {
     ws.on('close', () => {
       uiClients.delete(ws);
       console.log(`[WS /ws] Client disconnected (${uiClients.size} total)`);
+      broadcastClientCount();
     });
   });
 

--- a/simulator/src/app/globals.css
+++ b/simulator/src/app/globals.css
@@ -133,32 +133,17 @@ a {
   color: var(--sui-ocean);
 }
 
-mysten-dapp-kit-connect-button,
-mysten-dapp-kit-connect-modal {
-  --background: #ffffff;
-  --foreground: #011829;
-  --primary: #4da2ff;
-  --primary-foreground: #ffffff;
-  --secondary: #f4f8fc;
-  --secondary-foreground: #16314b;
-  --border: #d7e6f4;
-  --accent: #eef5fb;
-  --accent-foreground: #17324d;
-  --muted: #f8fbff;
-  --muted-foreground: #5d7893;
-  --popover: #ffffff;
-  --popover-foreground: #011829;
-  --ring: #4da2ff;
-  --font-sans: var(--font-main);
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
+@keyframes slide-in-right {
+  from {
+    opacity: 0;
+    transform: translateX(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
-mysten-dapp-kit-connect-button {
-  display: inline-flex;
-  --radius: 999px;
-}
-
-mysten-dapp-kit-connect-modal {
-  --radius: 1.1rem;
+.animate-slide-in {
+  animation: slide-in-right 0.25s ease-out;
 }

--- a/simulator/src/app/globals.css
+++ b/simulator/src/app/globals.css
@@ -2,42 +2,54 @@
 @tailwind components;
 @tailwind utilities;
 
-@import url('https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Inter+Tight:wght@500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
+@font-face {
+  font-family: 'TWK Everett';
+  src: local('TWK Everett'), local('TWKEverett-Regular');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TWK Everett';
+  src: local('TWK Everett Medium'), local('TWKEverett-Medium');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TWK Everett';
+  src: local('TWK Everett Bold'), local('TWKEverett-Bold');
+  font-weight: 600 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'TWK Everett';
+  src: local('TWK Everett ExtraBold'), local('TWKEverett-ExtraBold');
+  font-weight: 800;
+  font-style: normal;
+  font-display: swap;
+}
 
 :root {
-  --sui-sea: #4da2ff;
-  --sui-ocean: #011829;
-  --sui-aqua: #c0e6ff;
-  --sui-deep-ocean: #030f1c;
-  --sui-cloud: #ffffff;
-  --sui-paper: #f4f8fc;
-  --sui-shell: #eef5fb;
-  --sui-line: #d7e6f4;
-  --sui-line-strong: #bfd6ea;
-  --sui-ink: #16314b;
-  --sui-muted: #5d7893;
+  --sui-blue: #4da2ff;
+  --sui-black: #000000;
+  --sui-dark: #1a1a1a;
+  --sui-gray-900: #111111;
+  --sui-gray-700: #374151;
+  --sui-gray-500: #6b7280;
+  --sui-gray-400: #9ca3af;
+  --sui-gray-200: #e5e7eb;
+  --sui-gray-100: #f3f4f6;
+  --sui-gray-50: #f9fafb;
+  --sui-white: #ffffff;
   --sui-success: #1f8f6f;
-  --sui-warm: #f4a34f;
-  --background: #ffffff;
-  --foreground: #011829;
-  --primary: #4da2ff;
-  --primary-foreground: #ffffff;
-  --secondary: #f4f8fc;
-  --secondary-foreground: #16314b;
-  --border: #d7e6f4;
-  --accent: #eef5fb;
-  --accent-foreground: #17324d;
-  --muted: #f8fbff;
-  --muted-foreground: #5d7893;
-  --popover: #ffffff;
-  --popover-foreground: #011829;
-  --ring: #4da2ff;
-  --radius: 999px;
-  --font-sans: 'Google Sans', 'Google Sans Text', ui-sans-serif, system-ui, sans-serif;
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
-  --font-main: 'Google Sans', 'Google Sans Text', ui-sans-serif, system-ui, sans-serif;
-  --font-brand: 'TWK Everett', 'Inter Tight', ui-sans-serif, system-ui, sans-serif;
+  --font-main: 'TWK Everett', 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
   --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
 }
 
@@ -47,11 +59,10 @@ body {
 }
 
 body {
-  background:
-    radial-gradient(circle at top left, rgba(77, 162, 255, 0.1), transparent 28%),
-    radial-gradient(circle at top right, rgba(192, 230, 255, 0.28), transparent 32%),
-    linear-gradient(180deg, #f8fbff 0%, #eef5fb 100%);
-  color: var(--sui-ink);
+  background: var(--sui-white);
+  background-image: radial-gradient(circle, #d1d5db 1px, transparent 1px);
+  background-size: 24px 24px;
+  color: var(--sui-black);
   font-family: var(--font-main);
   overflow: hidden;
 }
@@ -63,12 +74,12 @@ a {
 
 * {
   scrollbar-width: thin;
-  scrollbar-color: rgba(77, 162, 255, 0.35) transparent;
+  scrollbar-color: rgba(0, 0, 0, 0.15) transparent;
 }
 
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {
@@ -76,16 +87,17 @@ a {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(77, 162, 255, 0.28);
+  background: rgba(0, 0, 0, 0.15);
   border-radius: 999px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(77, 162, 255, 0.46);
+  background: rgba(0, 0, 0, 0.25);
 }
 
 .font-brand {
-  font-family: var(--font-brand);
+  font-family: var(--font-main);
+  font-weight: 500;
 }
 
 .font-mono-ui {
@@ -93,44 +105,49 @@ a {
 }
 
 .surface-panel {
-  @apply rounded-[28px] border shadow-[0_12px_36px_rgba(1,24,41,0.05)] backdrop-blur;
-  background: rgba(255, 255, 255, 0.92);
-  border-color: var(--sui-line);
+  @apply rounded-2xl border border-gray-200 bg-white;
 }
 
 .surface-subtle {
-  @apply rounded-[24px] border backdrop-blur;
-  background: rgba(255, 255, 255, 0.74);
-  border-color: rgba(191, 214, 234, 0.75);
+  @apply rounded-xl border border-gray-100 bg-gray-50;
 }
 
 .surface-muted {
-  background: rgba(244, 248, 252, 0.9);
-  border: 1px solid rgba(191, 214, 234, 0.7);
+  @apply rounded-xl bg-gray-50;
 }
 
 .lesson-chip {
   @apply inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-[11px] font-medium;
-  background: rgba(255, 255, 255, 0.82);
-  color: #49637d;
-  border: 1px solid rgba(191, 214, 234, 0.72);
+  background: var(--sui-gray-50);
+  color: var(--sui-gray-500);
+  border: 1px solid var(--sui-gray-200);
 }
 
 .lesson-eyebrow {
-  @apply text-[11px] font-medium uppercase tracking-[0.22em];
-  color: #6f8ba6;
+  @apply inline-flex items-center gap-2 text-[12px] font-medium uppercase tracking-[0.14em];
+  color: var(--sui-black);
+}
+
+.lesson-eyebrow::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: var(--sui-blue);
+  border-radius: 2px;
+  flex-shrink: 0;
 }
 
 .prose-light p,
 .prose-light li {
-  color: #4b6781;
+  color: var(--sui-gray-500);
 }
 
 .prose-light h1,
 .prose-light h2,
 .prose-light h3,
 .prose-light strong {
-  color: var(--sui-ocean);
+  color: var(--sui-black);
 }
 
 @keyframes slide-in-right {

--- a/simulator/src/app/globals.css
+++ b/simulator/src/app/globals.css
@@ -1,0 +1,164 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import url('https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500;700&family=Inter+Tight:wght@500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
+
+:root {
+  --sui-sea: #4da2ff;
+  --sui-ocean: #011829;
+  --sui-aqua: #c0e6ff;
+  --sui-deep-ocean: #030f1c;
+  --sui-cloud: #ffffff;
+  --sui-paper: #f4f8fc;
+  --sui-shell: #eef5fb;
+  --sui-line: #d7e6f4;
+  --sui-line-strong: #bfd6ea;
+  --sui-ink: #16314b;
+  --sui-muted: #5d7893;
+  --sui-success: #1f8f6f;
+  --sui-warm: #f4a34f;
+  --background: #ffffff;
+  --foreground: #011829;
+  --primary: #4da2ff;
+  --primary-foreground: #ffffff;
+  --secondary: #f4f8fc;
+  --secondary-foreground: #16314b;
+  --border: #d7e6f4;
+  --accent: #eef5fb;
+  --accent-foreground: #17324d;
+  --muted: #f8fbff;
+  --muted-foreground: #5d7893;
+  --popover: #ffffff;
+  --popover-foreground: #011829;
+  --ring: #4da2ff;
+  --radius: 999px;
+  --font-sans: 'Google Sans', 'Google Sans Text', ui-sans-serif, system-ui, sans-serif;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-main: 'Google Sans', 'Google Sans Text', ui-sans-serif, system-ui, sans-serif;
+  --font-brand: 'TWK Everett', 'Inter Tight', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  background:
+    radial-gradient(circle at top left, rgba(77, 162, 255, 0.1), transparent 28%),
+    radial-gradient(circle at top right, rgba(192, 230, 255, 0.28), transparent 32%),
+    linear-gradient(180deg, #f8fbff 0%, #eef5fb 100%);
+  color: var(--sui-ink);
+  font-family: var(--font-main);
+  overflow: hidden;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(77, 162, 255, 0.35) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(77, 162, 255, 0.28);
+  border-radius: 999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(77, 162, 255, 0.46);
+}
+
+.font-brand {
+  font-family: var(--font-brand);
+}
+
+.font-mono-ui {
+  font-family: var(--font-mono);
+}
+
+.surface-panel {
+  @apply rounded-[28px] border shadow-[0_12px_36px_rgba(1,24,41,0.05)] backdrop-blur;
+  background: rgba(255, 255, 255, 0.92);
+  border-color: var(--sui-line);
+}
+
+.surface-subtle {
+  @apply rounded-[24px] border backdrop-blur;
+  background: rgba(255, 255, 255, 0.74);
+  border-color: rgba(191, 214, 234, 0.75);
+}
+
+.surface-muted {
+  background: rgba(244, 248, 252, 0.9);
+  border: 1px solid rgba(191, 214, 234, 0.7);
+}
+
+.lesson-chip {
+  @apply inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-[11px] font-medium;
+  background: rgba(255, 255, 255, 0.82);
+  color: #49637d;
+  border: 1px solid rgba(191, 214, 234, 0.72);
+}
+
+.lesson-eyebrow {
+  @apply text-[11px] font-medium uppercase tracking-[0.22em];
+  color: #6f8ba6;
+}
+
+.prose-light p,
+.prose-light li {
+  color: #4b6781;
+}
+
+.prose-light h1,
+.prose-light h2,
+.prose-light h3,
+.prose-light strong {
+  color: var(--sui-ocean);
+}
+
+mysten-dapp-kit-connect-button,
+mysten-dapp-kit-connect-modal {
+  --background: #ffffff;
+  --foreground: #011829;
+  --primary: #4da2ff;
+  --primary-foreground: #ffffff;
+  --secondary: #f4f8fc;
+  --secondary-foreground: #16314b;
+  --border: #d7e6f4;
+  --accent: #eef5fb;
+  --accent-foreground: #17324d;
+  --muted: #f8fbff;
+  --muted-foreground: #5d7893;
+  --popover: #ffffff;
+  --popover-foreground: #011829;
+  --ring: #4da2ff;
+  --font-sans: var(--font-main);
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+}
+
+mysten-dapp-kit-connect-button {
+  display: inline-flex;
+  --radius: 999px;
+}
+
+mysten-dapp-kit-connect-modal {
+  --radius: 1.1rem;
+}

--- a/simulator/src/app/layout.tsx
+++ b/simulator/src/app/layout.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import { SimulatorProvider } from '@/hooks/useSimulator';
+import Navbar from '@/components/Navbar';
+import SuiWalletProvider from '@/components/SuiWalletProvider';
+
+export const metadata: Metadata = {
+  title: 'SuiBotics Playground | Sui Testnet Robotics Lessons',
+  description: 'Sui-branded light-mode robotics playground with Sui testnet wallet support for the R1-R10 lesson track.',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="antialiased">
+        <SuiWalletProvider>
+          <SimulatorProvider>
+            <div className="flex h-screen flex-col">
+              <Navbar />
+              <main className="min-h-0 w-full flex-1 overflow-hidden px-3 pb-3 pt-3 sm:px-4">
+                {children}
+              </main>
+            </div>
+          </SimulatorProvider>
+        </SuiWalletProvider>
+      </body>
+    </html>
+  );
+}

--- a/simulator/src/app/layout.tsx
+++ b/simulator/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { SimulatorProvider } from '@/hooks/useSimulator';
 import Navbar from '@/components/Navbar';
 import SuiWalletProvider from '@/components/SuiWalletProvider';
+import { ToastContainer } from '@/components/Toast';
 
 export const metadata: Metadata = {
   title: 'SuiBotics Playground | Sui Testnet Robotics Lessons',
@@ -25,6 +26,7 @@ export default function RootLayout({
                 {children}
               </main>
             </div>
+            <ToastContainer />
           </SimulatorProvider>
         </SuiWalletProvider>
       </body>

--- a/simulator/src/app/module/[id]/page.tsx
+++ b/simulator/src/app/module/[id]/page.tsx
@@ -8,12 +8,8 @@ import { CATEGORY_META, getModuleOrder, getOrderedModules, MODULES } from '@/lib
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
-  BridgeIcon,
   ClockIcon,
-  CompassIcon,
   HardwareIcon,
-  ShieldWaveIcon,
-  StackIcon,
 } from '@/components/icons';
 
 interface ModuleDetail {
@@ -35,40 +31,33 @@ function simpleMarkdown(text: string): string {
   const html = text
     .replace(
       /```(\w+)?\n([\s\S]*?)```/g,
-      '<pre class="my-4 overflow-x-auto rounded-[20px] border border-[#d7e6f4] bg-[#f8fbff] p-4 text-[12px] leading-6 text-[#36526c]"><code>$2</code></pre>',
+      '<pre class="my-4 overflow-x-auto rounded-lg border border-gray-200 bg-gray-50 p-4 text-[12px] leading-6 text-gray-600"><code>$2</code></pre>',
     )
     .replace(
       /`([^`]+)`/g,
-      '<code class="rounded-full border border-[#d7e6f4] bg-white px-2 py-1 text-[12px] text-[#1d79e6]">$1</code>',
+      '<code class="rounded bg-gray-100 px-1.5 py-0.5 text-[12px] font-medium text-[#4da2ff]">$1</code>',
     )
-    .replace(/^### (.+)$/gm, '<h3 class="font-brand mt-8 text-[18px] font-medium tracking-[-0.03em] text-[#011829]">$1</h3>')
-    .replace(/^## (.+)$/gm, '<h2 class="font-brand mt-10 text-[1.45rem] font-medium tracking-[-0.04em] text-[#011829]">$1</h2>')
-    .replace(/^# (.+)$/gm, '<h1 class="font-brand mt-10 text-[1.7rem] font-medium tracking-[-0.05em] text-[#011829]">$1</h1>')
+    .replace(/^### (.+)$/gm, '<h3 class="mt-8 text-[18px] font-medium tracking-[-0.02em] text-black">$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2 class="mt-10 text-[1.45rem] font-medium tracking-[-0.02em] text-black">$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1 class="mt-10 text-[1.7rem] font-medium tracking-[-0.03em] text-black">$1</h1>')
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/\*(.+?)\*/g, '<em class="italic">$1</em>')
     .replace(
       /\[([^\]]+)\]\(([^)]+)\)/g,
-      '<a href="$2" class="font-medium text-[#1d79e6] underline underline-offset-4" target="_blank" rel="noopener noreferrer">$1</a>',
+      '<a href="$2" class="font-medium text-[#4da2ff] underline underline-offset-4" target="_blank" rel="noopener noreferrer">$1</a>',
     )
     .replace(/^- (.+)$/gm, '<li class="ml-5 list-disc">$1</li>')
     .replace(/^\d+\. (.+)$/gm, '<li class="ml-5 list-decimal">$1</li>')
-    .replace(/^---$/gm, '<hr class="my-8 border-[#d7e6f4]" />')
+    .replace(/^---$/gm, '<hr class="my-8 border-gray-200" />')
     .replace(
       /^> (.+)$/gm,
-      '<blockquote class="my-4 rounded-r-[20px] border-l-4 border-[#4da2ff] bg-[#f8fbff] px-4 py-3 italic text-[#4b6781]">$1</blockquote>',
+      '<blockquote class="my-4 rounded-r-lg border-l-4 border-[#4da2ff] bg-gray-50 px-4 py-3 italic text-gray-500">$1</blockquote>',
     )
-    .replace(/\n\n/g, '</p><p class="mt-4 text-[14px] leading-6 text-[#4b6781]">')
+    .replace(/\n\n/g, '</p><p class="mt-4 text-[14px] leading-6 text-gray-500">')
     .replace(/\n/g, '<br />');
 
-  return `<p class="text-[14px] leading-6 text-[#4b6781]">${html}</p>`;
+  return `<p class="text-[14px] leading-6 text-gray-500">${html}</p>`;
 }
-
-const CATEGORY_ICONS = {
-  Fundamentals: CompassIcon,
-  Integration: BridgeIcon,
-  Security: ShieldWaveIcon,
-  'Full-Stack': StackIcon,
-};
 
 export default function ModuleDetailPage() {
   const params = useParams();
@@ -80,15 +69,11 @@ export default function ModuleDetailPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!id) {
-      return;
-    }
+    if (!id) return;
 
     fetch(`/api/module/${id}`)
       .then((response) => {
-        if (!response.ok) {
-          throw new Error('Module not found');
-        }
+        if (!response.ok) throw new Error('Module not found');
         return response.json();
       })
       .then((data) => {
@@ -112,17 +97,17 @@ export default function ModuleDetailPage() {
 
   if (loading) {
     return (
-      <div className="surface-panel flex h-full items-center justify-center">
-        <div className="h-9 w-9 animate-spin rounded-full border-2 border-[#bfd6ea] border-t-[#4da2ff]" />
+      <div className="flex h-full items-center justify-center rounded-2xl border border-gray-200 bg-white">
+        <div className="h-9 w-9 animate-spin rounded-full border-2 border-gray-200 border-t-[#4da2ff]" />
       </div>
     );
   }
 
   if (error || !module) {
     return (
-      <div className="surface-panel flex h-full flex-col items-center justify-center gap-4">
-        <p className="text-sm text-[#5d7893]">{error ?? 'Module not found'}</p>
-        <Link href="/modules" className="inline-flex items-center gap-2 text-sm font-medium text-[#1d79e6]">
+      <div className="flex h-full flex-col items-center justify-center gap-4 rounded-2xl border border-gray-200 bg-white">
+        <p className="text-sm text-gray-500">{error ?? 'Module not found'}</p>
+        <Link href="/modules" className="inline-flex items-center gap-2 text-sm font-medium text-[#4da2ff]">
           <ArrowLeftIcon className="h-4 w-4" />
           Back to lessons
         </Link>
@@ -131,7 +116,6 @@ export default function ModuleDetailPage() {
   }
 
   const categoryMeta = CATEGORY_META[module.category];
-  const CategoryIcon = CATEGORY_ICONS[module.category as keyof typeof CATEGORY_ICONS] ?? CompassIcon;
 
   const simulatorSteps = [
     'Start the simulator from the root with `cd simulator && npm run dev`.',
@@ -141,8 +125,8 @@ export default function ModuleDetailPage() {
 
   return (
     <div className="flex h-full flex-col overflow-y-auto pb-5">
-      <section className="surface-panel mb-4 px-5 py-5 sm:px-6">
-        <Link href="/modules" className="inline-flex items-center gap-2 text-[12px] font-medium text-[#1d79e6]">
+      <section className="mb-4 rounded-2xl border border-gray-200 bg-white px-5 py-5 sm:px-6">
+        <Link href="/modules" className="inline-flex items-center gap-2 text-[12px] font-medium text-[#4da2ff]">
           <ArrowLeftIcon className="h-4 w-4" />
           Back to lessons
         </Link>
@@ -150,36 +134,35 @@ export default function ModuleDetailPage() {
         <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_280px]">
           <div>
             <div className="flex flex-wrap items-center gap-2">
-              <span className="lesson-chip text-[10px]">
-                <CategoryIcon className="h-4 w-4" />
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1.5 text-[10px] font-medium text-gray-500">
                 {categoryMeta.eyebrow}
               </span>
-              <span className="lesson-chip text-[10px]">
-                <ClockIcon className="h-4 w-4" />
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1.5 text-[10px] font-medium text-gray-500">
+                <ClockIcon className="h-3.5 w-3.5" />
                 {module.time}
               </span>
-              <span className="lesson-chip text-[10px]">
-                {module.hardware ? <HardwareIcon className="h-4 w-4" /> : <CategoryIcon className="h-4 w-4" />}
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1.5 text-[10px] font-medium text-gray-500">
+                <HardwareIcon className="h-3.5 w-3.5" />
                 {module.hardware ? 'Simulator-ready' : 'Software-first'}
               </span>
             </div>
 
-            <div className="mt-4 text-[10px] uppercase tracking-[0.22em] text-[#6f8ba6]">{module.id}</div>
-            <h1 className="font-brand mt-2 text-[2rem] font-medium leading-[1.02] tracking-[-0.05em] text-[#011829] sm:text-[2.35rem]">
+            <div className="mt-4 text-[11px] font-medium uppercase tracking-[0.12em] text-gray-400">{module.id}</div>
+            <h1 className="mt-2 text-[2rem] font-medium leading-[1.02] tracking-[-0.03em] text-black sm:text-[2.35rem]">
               {module.title}
             </h1>
-            <div className="mt-2 text-[14px] font-medium text-[#36526c] sm:text-[15px]">{module.subtitle}</div>
-            <p className="mt-3 max-w-3xl text-[14px] leading-6 text-[#5d7893] sm:text-[15px]">{module.summary}</p>
+            <div className="mt-2 text-[14px] font-medium text-gray-600 sm:text-[15px]">{module.subtitle}</div>
+            <p className="mt-3 max-w-3xl text-[14px] leading-6 text-gray-500 sm:text-[15px]">{module.summary}</p>
           </div>
 
-          <div className="surface-muted rounded-[20px] p-4">
+          <div className="rounded-xl bg-gray-50 p-4">
             <div className="lesson-eyebrow">Build surface</div>
-            <div className="font-brand mt-2 text-[16px] font-medium text-[#011829]">{module.artifact}</div>
-            <p className="mt-2 text-[13px] leading-5 text-[#5d7893]">{categoryMeta.description}</p>
+            <div className="mt-2 text-[16px] font-medium text-black">{module.artifact}</div>
+            <p className="mt-2 text-[13px] leading-5 text-gray-500">{categoryMeta.description}</p>
 
             <div className="mt-4 space-y-2">
               {module.focus.map((item) => (
-                <div key={item} className="rounded-[14px] border border-[#d7e6f4] bg-white px-3 py-2.5 text-[12px] text-[#36526c]">
+                <div key={item} className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-[12px] text-gray-600">
                   {item}
                 </div>
               ))}
@@ -188,39 +171,39 @@ export default function ModuleDetailPage() {
         </div>
       </section>
 
-      <section className="surface-panel mb-4 px-4 py-4 sm:px-5">
+      <section className="mb-4 rounded-2xl border border-gray-200 bg-white px-4 py-4 sm:px-5">
         <div className="mb-3 flex items-center justify-between gap-3">
           <div>
             <div className="lesson-eyebrow">Curriculum track</div>
-            <h2 className="font-brand mt-1 text-[1.05rem] font-medium tracking-[-0.04em] text-[#011829]">
-              Keep the full R1-R10 sequence visible
+            <h2 className="mt-1 text-[1.05rem] font-medium tracking-[-0.02em] text-black">
+              Full R1-R10 sequence
             </h2>
           </div>
-          <Link href="/modules" className="text-[12px] font-medium text-[#1d79e6]">
-            Open lesson index
+          <Link href="/modules" className="text-[12px] font-medium text-[#4da2ff]">
+            All lessons
           </Link>
         </div>
 
-        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
+        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
           {orderedModules.map((entry) => {
             const active = entry.id === module.id;
-            const stateClassName = active
-              ? 'border-[#b7d5f1] bg-[#f4f9ff]'
-              : 'border-[#d7e6f4] bg-white hover:border-[#bfd6ea]';
-
             return (
               <Link
                 key={entry.id}
                 href={`/module/${entry.id}`}
-                className={`rounded-[16px] border px-3 py-3 transition ${stateClassName}`}
+                className={`rounded-xl border px-3 py-3 transition ${
+                  active
+                    ? 'border-[#4da2ff] bg-[#4da2ff]/5'
+                    : 'border-gray-200 bg-white hover:border-gray-300'
+                }`}
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">{entry.id}</div>
-                    <div className="font-brand mt-1 text-[14px] font-medium text-[#17324d]">{entry.title}</div>
-                    <div className="mt-1 text-[12px] leading-5 text-[#6f8ba6]">{entry.subtitle}</div>
+                    <div className="text-[10px] font-medium uppercase tracking-[0.1em] text-gray-400">{entry.id}</div>
+                    <div className="mt-1 text-[14px] font-medium text-black">{entry.title}</div>
+                    <div className="mt-0.5 text-[12px] text-gray-500">{entry.subtitle}</div>
                   </div>
-                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] text-[10px] font-medium text-[#17324d]">
+                  <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-[10px] font-medium text-gray-600">
                     {getModuleOrder(entry.id)}
                   </div>
                 </div>
@@ -232,20 +215,20 @@ export default function ModuleDetailPage() {
 
       <section className="mb-4 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_300px]">
         <div className="space-y-4">
-          <div className="surface-panel px-5 py-5">
+          <div className="rounded-2xl border border-gray-200 bg-white px-5 py-5">
             <div className="mb-3">
               <div className="lesson-eyebrow">Architecture</div>
-              <h2 className="font-brand mt-1 text-[1.15rem] font-medium tracking-[-0.04em] text-[#011829]">
+              <h2 className="mt-1 text-[1.15rem] font-medium tracking-[-0.02em] text-black">
                 How this lesson fits the system
               </h2>
             </div>
             <DiagramCanvas moduleId={module.id} />
           </div>
 
-          <div className="surface-panel px-5 py-5 sm:px-6">
+          <div className="rounded-2xl border border-gray-200 bg-white px-5 py-5 sm:px-6">
             <div className="mb-4">
               <div className="lesson-eyebrow">Lesson content</div>
-              <h2 className="font-brand mt-1 text-[1.2rem] font-medium tracking-[-0.04em] text-[#011829] sm:text-[1.35rem]">
+              <h2 className="mt-1 text-[1.2rem] font-medium tracking-[-0.02em] text-black sm:text-[1.35rem]">
                 Source material and implementation notes
               </h2>
             </div>
@@ -253,25 +236,25 @@ export default function ModuleDetailPage() {
             {module.readme ? (
               <div className="prose-light" dangerouslySetInnerHTML={{ __html: simpleMarkdown(module.readme) }} />
             ) : (
-              <p className="text-sm text-[#5d7893]">No README content was found for this lesson.</p>
+              <p className="text-sm text-gray-500">No README content was found for this lesson.</p>
             )}
           </div>
 
           {navigation.next ? (
-            <div className="surface-panel px-5 py-5 sm:px-6">
+            <div className="rounded-2xl border border-gray-200 bg-white px-5 py-5 sm:px-6">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <div className="lesson-eyebrow">Next lesson</div>
-                  <h2 className="font-brand mt-1 text-[1.1rem] font-medium tracking-[-0.04em] text-[#011829]">
+                  <h2 className="mt-1 text-[1.1rem] font-medium tracking-[-0.02em] text-black">
                     Continue to {navigation.next.id} · {navigation.next.title}
                   </h2>
-                  <p className="mt-2 text-[13px] leading-5 text-[#6f8ba6]">
-                    Keep moving through the robotics track in order.
+                  <p className="mt-2 text-[13px] leading-5 text-gray-500">
+                    Keep moving through the robotics track.
                   </p>
                 </div>
                 <Link
                   href={`/module/${navigation.next.id}`}
-                  className="inline-flex items-center gap-2 rounded-full border border-[#c9def1] bg-white px-4 py-2.5 text-[13px] font-medium text-[#17324d] transition hover:border-[#9fc9ef]"
+                  className="inline-flex items-center gap-2 rounded-full bg-[#4da2ff] px-5 py-2.5 text-[13px] font-medium text-white transition hover:bg-[#3b8de6]"
                 >
                   Go to {navigation.next.id}
                   <ArrowRightIcon className="h-4 w-4" />
@@ -282,47 +265,47 @@ export default function ModuleDetailPage() {
         </div>
 
         <div className="space-y-4 xl:sticky xl:top-4">
-          <div className="surface-panel px-4 py-4">
+          <div className="rounded-2xl border border-gray-200 bg-white px-4 py-4">
             <div className="lesson-eyebrow">Simulator route</div>
-            <h3 className="font-brand mt-1 text-[15px] font-medium tracking-[-0.03em] text-[#011829]">
-              Run this lesson cleanly
+            <h3 className="mt-1 text-[15px] font-medium tracking-[-0.02em] text-black">
+              Run this lesson
             </h3>
             <div className="mt-3 space-y-2.5">
               {simulatorSteps.map((step, index) => (
-                <div key={step} className="rounded-[14px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3">
-                  <div className="mb-2 inline-flex h-6 w-6 items-center justify-center rounded-full border border-[#d7e6f4] bg-white text-[10px] font-medium text-[#17324d]">
+                <div key={step} className="rounded-lg bg-gray-50 px-3 py-3">
+                  <div className="mb-2 inline-flex h-6 w-6 items-center justify-center rounded-full bg-white text-[10px] font-medium text-gray-600 shadow-sm">
                     {index + 1}
                   </div>
-                  <p className="text-[12px] leading-5 text-[#4b6781]">{step}</p>
+                  <p className="text-[12px] leading-5 text-gray-500">{step}</p>
                 </div>
               ))}
             </div>
           </div>
 
-          <div className="surface-panel px-4 py-4">
+          <div className="rounded-2xl border border-gray-200 bg-white px-4 py-4">
             <div className="lesson-eyebrow">Core concepts</div>
-            <h3 className="font-brand mt-1 text-[15px] font-medium tracking-[-0.03em] text-[#011829]">
-              What to understand before moving on
+            <h3 className="mt-1 text-[15px] font-medium tracking-[-0.02em] text-black">
+              Key takeaways
             </h3>
             <div className="mt-3 flex flex-wrap gap-2">
               {module.concepts.map((concept) => (
-                <span key={concept} className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-1.5 text-[11px] text-[#36526c]">
+                <span key={concept} className="rounded-full bg-gray-100 px-3 py-1.5 text-[11px] font-medium text-gray-600">
                   {concept}
                 </span>
               ))}
             </div>
           </div>
 
-          <div className="surface-panel px-4 py-4">
+          <div className="rounded-2xl border border-gray-200 bg-white px-4 py-4">
             <div className="lesson-eyebrow">Progression</div>
             <div className="mt-3 grid gap-2.5">
               {navigation.previous ? (
                 <Link
                   href={`/module/${navigation.previous.id}`}
-                  className="rounded-[14px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3 transition hover:border-[#bfd6ea]"
+                  className="rounded-lg bg-gray-50 px-3 py-3 transition hover:bg-gray-100"
                 >
-                  <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Previous</div>
-                  <div className="font-brand mt-1.5 text-[14px] font-medium text-[#011829]">
+                  <div className="text-[10px] font-medium uppercase tracking-[0.1em] text-gray-400">Previous</div>
+                  <div className="mt-1.5 text-[14px] font-medium text-black">
                     {navigation.previous.id} · {navigation.previous.title}
                   </div>
                 </Link>
@@ -331,10 +314,10 @@ export default function ModuleDetailPage() {
               {navigation.next ? (
                 <Link
                   href={`/module/${navigation.next.id}`}
-                  className="rounded-[14px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3 transition hover:border-[#bfd6ea]"
+                  className="rounded-lg bg-gray-50 px-3 py-3 transition hover:bg-gray-100"
                 >
-                  <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Next</div>
-                  <div className="font-brand mt-1.5 text-[14px] font-medium text-[#011829]">
+                  <div className="text-[10px] font-medium uppercase tracking-[0.1em] text-gray-400">Next</div>
+                  <div className="mt-1.5 text-[14px] font-medium text-black">
                     {navigation.next.id} · {navigation.next.title}
                   </div>
                 </Link>

--- a/simulator/src/app/module/[id]/page.tsx
+++ b/simulator/src/app/module/[id]/page.tsx
@@ -1,0 +1,348 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import DiagramCanvas from '@/components/DiagramCanvas';
+import { CATEGORY_META, getModuleOrder, getOrderedModules, MODULES } from '@/lib/modules';
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  BridgeIcon,
+  ClockIcon,
+  CompassIcon,
+  HardwareIcon,
+  ShieldWaveIcon,
+  StackIcon,
+} from '@/components/icons';
+
+interface ModuleDetail {
+  id: string;
+  title: string;
+  subtitle: string;
+  category: string;
+  time: string;
+  hardware: boolean;
+  simScript: string;
+  summary: string;
+  artifact: string;
+  focus: string[];
+  concepts: string[];
+  readme?: string;
+}
+
+function simpleMarkdown(text: string): string {
+  const html = text
+    .replace(
+      /```(\w+)?\n([\s\S]*?)```/g,
+      '<pre class="my-4 overflow-x-auto rounded-[20px] border border-[#d7e6f4] bg-[#f8fbff] p-4 text-[12px] leading-6 text-[#36526c]"><code>$2</code></pre>',
+    )
+    .replace(
+      /`([^`]+)`/g,
+      '<code class="rounded-full border border-[#d7e6f4] bg-white px-2 py-1 text-[12px] text-[#1d79e6]">$1</code>',
+    )
+    .replace(/^### (.+)$/gm, '<h3 class="font-brand mt-8 text-[18px] font-medium tracking-[-0.03em] text-[#011829]">$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2 class="font-brand mt-10 text-[1.45rem] font-medium tracking-[-0.04em] text-[#011829]">$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1 class="font-brand mt-10 text-[1.7rem] font-medium tracking-[-0.05em] text-[#011829]">$1</h1>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em class="italic">$1</em>')
+    .replace(
+      /\[([^\]]+)\]\(([^)]+)\)/g,
+      '<a href="$2" class="font-medium text-[#1d79e6] underline underline-offset-4" target="_blank" rel="noopener noreferrer">$1</a>',
+    )
+    .replace(/^- (.+)$/gm, '<li class="ml-5 list-disc">$1</li>')
+    .replace(/^\d+\. (.+)$/gm, '<li class="ml-5 list-decimal">$1</li>')
+    .replace(/^---$/gm, '<hr class="my-8 border-[#d7e6f4]" />')
+    .replace(
+      /^> (.+)$/gm,
+      '<blockquote class="my-4 rounded-r-[20px] border-l-4 border-[#4da2ff] bg-[#f8fbff] px-4 py-3 italic text-[#4b6781]">$1</blockquote>',
+    )
+    .replace(/\n\n/g, '</p><p class="mt-4 text-[14px] leading-6 text-[#4b6781]">')
+    .replace(/\n/g, '<br />');
+
+  return `<p class="text-[14px] leading-6 text-[#4b6781]">${html}</p>`;
+}
+
+const CATEGORY_ICONS = {
+  Fundamentals: CompassIcon,
+  Integration: BridgeIcon,
+  Security: ShieldWaveIcon,
+  'Full-Stack': StackIcon,
+};
+
+export default function ModuleDetailPage() {
+  const params = useParams();
+  const id = String(params.id ?? '').toUpperCase();
+  const orderedModules = useMemo(() => getOrderedModules(MODULES), []);
+
+  const [module, setModule] = useState<ModuleDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+
+    fetch(`/api/module/${id}`)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Module not found');
+        }
+        return response.json();
+      })
+      .then((data) => {
+        setModule(data);
+        setLoading(false);
+      })
+      .catch((fetchError: Error) => {
+        setError(fetchError.message);
+        setLoading(false);
+      });
+  }, [id]);
+
+  const navigation = useMemo(() => {
+    const index = orderedModules.findIndex((entry) => entry.id === id);
+    return {
+      previous: index > 0 ? orderedModules[index - 1] : null,
+      next: index >= 0 && index < orderedModules.length - 1 ? orderedModules[index + 1] : null,
+      index,
+    };
+  }, [id, orderedModules]);
+
+  if (loading) {
+    return (
+      <div className="surface-panel flex h-full items-center justify-center">
+        <div className="h-9 w-9 animate-spin rounded-full border-2 border-[#bfd6ea] border-t-[#4da2ff]" />
+      </div>
+    );
+  }
+
+  if (error || !module) {
+    return (
+      <div className="surface-panel flex h-full flex-col items-center justify-center gap-4">
+        <p className="text-sm text-[#5d7893]">{error ?? 'Module not found'}</p>
+        <Link href="/modules" className="inline-flex items-center gap-2 text-sm font-medium text-[#1d79e6]">
+          <ArrowLeftIcon className="h-4 w-4" />
+          Back to lessons
+        </Link>
+      </div>
+    );
+  }
+
+  const categoryMeta = CATEGORY_META[module.category];
+  const CategoryIcon = CATEGORY_ICONS[module.category as keyof typeof CATEGORY_ICONS] ?? CompassIcon;
+
+  const simulatorSteps = [
+    'Start the simulator from the root with `cd simulator && npm run dev`.',
+    'Open `http://localhost:3000` and keep the playground visible.',
+    `Run the module path: \`${module.simScript}\`.`,
+  ];
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto pb-5">
+      <section className="surface-panel mb-4 px-5 py-5 sm:px-6">
+        <Link href="/modules" className="inline-flex items-center gap-2 text-[12px] font-medium text-[#1d79e6]">
+          <ArrowLeftIcon className="h-4 w-4" />
+          Back to lessons
+        </Link>
+
+        <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_280px]">
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="lesson-chip text-[10px]">
+                <CategoryIcon className="h-4 w-4" />
+                {categoryMeta.eyebrow}
+              </span>
+              <span className="lesson-chip text-[10px]">
+                <ClockIcon className="h-4 w-4" />
+                {module.time}
+              </span>
+              <span className="lesson-chip text-[10px]">
+                {module.hardware ? <HardwareIcon className="h-4 w-4" /> : <CategoryIcon className="h-4 w-4" />}
+                {module.hardware ? 'Simulator-ready' : 'Software-first'}
+              </span>
+            </div>
+
+            <div className="mt-4 text-[10px] uppercase tracking-[0.22em] text-[#6f8ba6]">{module.id}</div>
+            <h1 className="font-brand mt-2 text-[2rem] font-medium leading-[1.02] tracking-[-0.05em] text-[#011829] sm:text-[2.35rem]">
+              {module.title}
+            </h1>
+            <div className="mt-2 text-[14px] font-medium text-[#36526c] sm:text-[15px]">{module.subtitle}</div>
+            <p className="mt-3 max-w-3xl text-[14px] leading-6 text-[#5d7893] sm:text-[15px]">{module.summary}</p>
+          </div>
+
+          <div className="surface-muted rounded-[20px] p-4">
+            <div className="lesson-eyebrow">Build surface</div>
+            <div className="font-brand mt-2 text-[16px] font-medium text-[#011829]">{module.artifact}</div>
+            <p className="mt-2 text-[13px] leading-5 text-[#5d7893]">{categoryMeta.description}</p>
+
+            <div className="mt-4 space-y-2">
+              {module.focus.map((item) => (
+                <div key={item} className="rounded-[14px] border border-[#d7e6f4] bg-white px-3 py-2.5 text-[12px] text-[#36526c]">
+                  {item}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="surface-panel mb-4 px-4 py-4 sm:px-5">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <div className="lesson-eyebrow">Curriculum track</div>
+            <h2 className="font-brand mt-1 text-[1.05rem] font-medium tracking-[-0.04em] text-[#011829]">
+              Keep the full R1-R10 sequence visible
+            </h2>
+          </div>
+          <Link href="/modules" className="text-[12px] font-medium text-[#1d79e6]">
+            Open lesson index
+          </Link>
+        </div>
+
+        <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
+          {orderedModules.map((entry) => {
+            const active = entry.id === module.id;
+            const stateClassName = active
+              ? 'border-[#b7d5f1] bg-[#f4f9ff]'
+              : 'border-[#d7e6f4] bg-white hover:border-[#bfd6ea]';
+
+            return (
+              <Link
+                key={entry.id}
+                href={`/module/${entry.id}`}
+                className={`rounded-[16px] border px-3 py-3 transition ${stateClassName}`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">{entry.id}</div>
+                    <div className="font-brand mt-1 text-[14px] font-medium text-[#17324d]">{entry.title}</div>
+                    <div className="mt-1 text-[12px] leading-5 text-[#6f8ba6]">{entry.subtitle}</div>
+                  </div>
+                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] text-[10px] font-medium text-[#17324d]">
+                    {getModuleOrder(entry.id)}
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="mb-4 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_300px]">
+        <div className="space-y-4">
+          <div className="surface-panel px-5 py-5">
+            <div className="mb-3">
+              <div className="lesson-eyebrow">Architecture</div>
+              <h2 className="font-brand mt-1 text-[1.15rem] font-medium tracking-[-0.04em] text-[#011829]">
+                How this lesson fits the system
+              </h2>
+            </div>
+            <DiagramCanvas moduleId={module.id} />
+          </div>
+
+          <div className="surface-panel px-5 py-5 sm:px-6">
+            <div className="mb-4">
+              <div className="lesson-eyebrow">Lesson content</div>
+              <h2 className="font-brand mt-1 text-[1.2rem] font-medium tracking-[-0.04em] text-[#011829] sm:text-[1.35rem]">
+                Source material and implementation notes
+              </h2>
+            </div>
+
+            {module.readme ? (
+              <div className="prose-light" dangerouslySetInnerHTML={{ __html: simpleMarkdown(module.readme) }} />
+            ) : (
+              <p className="text-sm text-[#5d7893]">No README content was found for this lesson.</p>
+            )}
+          </div>
+
+          {navigation.next ? (
+            <div className="surface-panel px-5 py-5 sm:px-6">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div className="lesson-eyebrow">Next lesson</div>
+                  <h2 className="font-brand mt-1 text-[1.1rem] font-medium tracking-[-0.04em] text-[#011829]">
+                    Continue to {navigation.next.id} · {navigation.next.title}
+                  </h2>
+                  <p className="mt-2 text-[13px] leading-5 text-[#6f8ba6]">
+                    Keep moving through the robotics track in order.
+                  </p>
+                </div>
+                <Link
+                  href={`/module/${navigation.next.id}`}
+                  className="inline-flex items-center gap-2 rounded-full border border-[#c9def1] bg-white px-4 py-2.5 text-[13px] font-medium text-[#17324d] transition hover:border-[#9fc9ef]"
+                >
+                  Go to {navigation.next.id}
+                  <ArrowRightIcon className="h-4 w-4" />
+                </Link>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="space-y-4 xl:sticky xl:top-4">
+          <div className="surface-panel px-4 py-4">
+            <div className="lesson-eyebrow">Simulator route</div>
+            <h3 className="font-brand mt-1 text-[15px] font-medium tracking-[-0.03em] text-[#011829]">
+              Run this lesson cleanly
+            </h3>
+            <div className="mt-3 space-y-2.5">
+              {simulatorSteps.map((step, index) => (
+                <div key={step} className="rounded-[14px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3">
+                  <div className="mb-2 inline-flex h-6 w-6 items-center justify-center rounded-full border border-[#d7e6f4] bg-white text-[10px] font-medium text-[#17324d]">
+                    {index + 1}
+                  </div>
+                  <p className="text-[12px] leading-5 text-[#4b6781]">{step}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="surface-panel px-4 py-4">
+            <div className="lesson-eyebrow">Core concepts</div>
+            <h3 className="font-brand mt-1 text-[15px] font-medium tracking-[-0.03em] text-[#011829]">
+              What to understand before moving on
+            </h3>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {module.concepts.map((concept) => (
+                <span key={concept} className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-1.5 text-[11px] text-[#36526c]">
+                  {concept}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="surface-panel px-4 py-4">
+            <div className="lesson-eyebrow">Progression</div>
+            <div className="mt-3 grid gap-2.5">
+              {navigation.previous ? (
+                <Link
+                  href={`/module/${navigation.previous.id}`}
+                  className="rounded-[14px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3 transition hover:border-[#bfd6ea]"
+                >
+                  <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Previous</div>
+                  <div className="font-brand mt-1.5 text-[14px] font-medium text-[#011829]">
+                    {navigation.previous.id} · {navigation.previous.title}
+                  </div>
+                </Link>
+              ) : null}
+
+              {navigation.next ? (
+                <Link
+                  href={`/module/${navigation.next.id}`}
+                  className="rounded-[14px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3 transition hover:border-[#bfd6ea]"
+                >
+                  <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Next</div>
+                  <div className="font-brand mt-1.5 text-[14px] font-medium text-[#011829]">
+                    {navigation.next.id} · {navigation.next.title}
+                  </div>
+                </Link>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/simulator/src/app/modules/page.tsx
+++ b/simulator/src/app/modules/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import ModuleCard from '@/components/ModuleCard';
+import { getCurriculumPhases, getModuleOrder, MODULES } from '@/lib/modules';
+
+const FILTER_OPTIONS = ['All', 'Fundamentals', 'Integration', 'Security', 'Full-Stack'];
+
+export default function ModulesPage() {
+  const [filter, setFilter] = useState('All');
+
+  const groupedModules = useMemo(() => {
+    const visibleModules = filter === 'All' ? MODULES : MODULES.filter((module) => module.category === filter);
+    return getCurriculumPhases(visibleModules);
+  }, [filter]);
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto pb-5">
+      <section className="surface-panel mb-4 px-5 py-5 sm:px-6">
+        <div className="max-w-3xl">
+          <div className="lesson-eyebrow">Lesson index</div>
+          <h1 className="font-brand mt-2 text-[1.7rem] font-medium tracking-[-0.05em] text-[#011829] sm:text-[2.05rem]">
+            The robotics track, ordered cleanly from R1 to R10.
+          </h1>
+          <p className="mt-3 text-[14px] leading-6 text-[#5d7893] sm:text-[15px]">
+            Use this page as the full curriculum index. Each section preserves the real lesson sequence instead of
+            restarting the numbering inside each phase.
+          </p>
+        </div>
+
+        <div className="mt-4 flex gap-2 overflow-x-auto pb-1">
+          {FILTER_OPTIONS.map((option) => (
+            <button
+              key={option}
+              onClick={() => setFilter(option)}
+              className={`shrink-0 rounded-full border px-3 py-2 text-[12px] font-medium transition ${
+                filter === option
+                  ? 'border-[#c9def1] bg-white text-[#17324d]'
+                  : 'border-[#d7e6f4] bg-[#f8fbff] text-[#5d7893]'
+              }`}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <div className="space-y-4">
+        {groupedModules.map(({ category, meta, modules }) => {
+          if (modules.length === 0) {
+            return null;
+          }
+
+          return (
+            <section key={category} className="surface-panel px-5 py-5 sm:px-6">
+              <div className="mb-4 flex items-end justify-between gap-3">
+                <div>
+                  <div className="lesson-eyebrow">{meta.eyebrow}</div>
+                  <h2 className="font-brand mt-1 text-[1.1rem] font-medium tracking-[-0.04em] text-[#011829]">
+                    {category}
+                  </h2>
+                  <p className="mt-1 text-[13px] leading-5 text-[#6f8ba6]">{meta.description}</p>
+                </div>
+                <div className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-1.5 text-[11px] text-[#6f8ba6]">
+                  {modules[0]?.id} to {modules[modules.length - 1]?.id}
+                </div>
+              </div>
+
+              <div className="grid gap-3 lg:grid-cols-2">
+                {modules.map((module) => (
+                  <ModuleCard
+                    key={module.id}
+                    order={getModuleOrder(module.id)}
+                    id={module.id}
+                    title={module.title}
+                    subtitle={module.subtitle}
+                    category={module.category}
+                    time={module.time}
+                    hardware={module.hardware}
+                    summary={module.summary}
+                    artifact={module.artifact}
+                    focus={module.focus}
+                  />
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/simulator/src/app/modules/page.tsx
+++ b/simulator/src/app/modules/page.tsx
@@ -16,15 +16,14 @@ export default function ModulesPage() {
 
   return (
     <div className="flex h-full flex-col overflow-y-auto pb-5">
-      <section className="surface-panel mb-4 px-5 py-5 sm:px-6">
+      <section className="mb-4 rounded-2xl border border-gray-200 bg-white px-5 py-5 sm:px-6">
         <div className="max-w-3xl">
           <div className="lesson-eyebrow">Lesson index</div>
-          <h1 className="font-brand mt-2 text-[1.7rem] font-medium tracking-[-0.05em] text-[#011829] sm:text-[2.05rem]">
-            The robotics track, ordered cleanly from R1 to R10.
+          <h1 className="mt-2 text-[1.7rem] font-medium tracking-[-0.03em] text-black sm:text-[2.05rem]">
+            The robotics track, R1 to R10.
           </h1>
-          <p className="mt-3 text-[14px] leading-6 text-[#5d7893] sm:text-[15px]">
-            Use this page as the full curriculum index. Each section preserves the real lesson sequence instead of
-            restarting the numbering inside each phase.
+          <p className="mt-3 text-[14px] leading-6 text-gray-500 sm:text-[15px]">
+            The full curriculum index. Each section preserves the real lesson sequence.
           </p>
         </div>
 
@@ -33,10 +32,10 @@ export default function ModulesPage() {
             <button
               key={option}
               onClick={() => setFilter(option)}
-              className={`shrink-0 rounded-full border px-3 py-2 text-[12px] font-medium transition ${
+              className={`shrink-0 rounded-full px-3 py-2 text-[12px] font-medium transition ${
                 filter === option
-                  ? 'border-[#c9def1] bg-white text-[#17324d]'
-                  : 'border-[#d7e6f4] bg-[#f8fbff] text-[#5d7893]'
+                  ? 'bg-black text-white'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
               }`}
             >
               {option}
@@ -47,22 +46,20 @@ export default function ModulesPage() {
 
       <div className="space-y-4">
         {groupedModules.map(({ category, meta, modules }) => {
-          if (modules.length === 0) {
-            return null;
-          }
+          if (modules.length === 0) return null;
 
           return (
-            <section key={category} className="surface-panel px-5 py-5 sm:px-6">
+            <section key={category} className="rounded-2xl border border-gray-200 bg-white px-5 py-5 sm:px-6">
               <div className="mb-4 flex items-end justify-between gap-3">
                 <div>
                   <div className="lesson-eyebrow">{meta.eyebrow}</div>
-                  <h2 className="font-brand mt-1 text-[1.1rem] font-medium tracking-[-0.04em] text-[#011829]">
+                  <h2 className="mt-1 text-[1.1rem] font-medium tracking-[-0.02em] text-black">
                     {category}
                   </h2>
-                  <p className="mt-1 text-[13px] leading-5 text-[#6f8ba6]">{meta.description}</p>
+                  <p className="mt-1 text-[13px] leading-5 text-gray-500">{meta.description}</p>
                 </div>
-                <div className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-1.5 text-[11px] text-[#6f8ba6]">
-                  {modules[0]?.id} to {modules[modules.length - 1]?.id}
+                <div className="rounded-full bg-gray-100 px-3 py-1.5 text-[11px] font-medium text-gray-500">
+                  {modules[0]?.id} - {modules[modules.length - 1]?.id}
                 </div>
               </div>
 

--- a/simulator/src/app/page.tsx
+++ b/simulator/src/app/page.tsx
@@ -1,117 +1,162 @@
 import Link from 'next/link';
-import { ArrowRightIcon, ClockIcon } from '@/components/icons';
-import { CATEGORY_ORDER, getCurriculumPhases, getModuleOrder, MODULES } from '@/lib/modules';
+import { ArrowRightIcon } from '@/components/icons';
+import { getCurriculumPhases, getModuleOrder, MODULES } from '@/lib/modules';
 
 const PHASES = getCurriculumPhases(MODULES);
 
+const FEATURES_LEFT = [
+  { title: 'No hardware required', desc: 'Virtual Bittle simulator replaces the physical robot for every lesson.' },
+  { title: 'Real on-chain transactions', desc: 'Every robot action is signed and submitted to Sui testnet.' },
+  { title: 'Full R1-R10 curriculum', desc: '10 sequenced lessons from serial control to rental-platform capstone.' },
+  { title: 'TCP serial bridge', desc: 'R modules connect to the simulator via the same serial protocol.' },
+];
+
+const FEATURES_RIGHT = [
+  { title: '3D robot viewport', desc: 'Three.js animated Unitree GO1 with walk cycles, poses, and physics.' },
+  { title: 'Wallet-gated actions', desc: 'Connect any Sui wallet to sign transactions before the robot moves.' },
+  { title: 'Live on-chain status', desc: 'Queue length, total actions, and pending transactions in real time.' },
+  { title: 'Module browser', desc: 'Architecture diagrams, rendered README content, and run instructions.' },
+];
+
 export default function HomePage() {
   return (
-    <div className="flex h-full flex-col overflow-y-auto pb-4">
-      <section className="surface-panel mb-3 px-4 py-5 sm:px-6 lg:px-8 lg:py-7">
-        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_330px] lg:gap-8">
-          <div className="max-w-5xl">
-            <div className="lesson-eyebrow">Sui robotics playground</div>
-            <h1 className="mt-3 max-w-4xl text-[2.45rem] font-medium leading-[0.94] tracking-[-0.075em] text-[#011829] sm:text-[3.35rem] lg:text-[4.6rem]">
-              Learn the full R1-R10 robotics track in one clean workspace.
-            </h1>
-            <p className="mt-5 max-w-2xl text-[15px] leading-7 text-[#5d7893] sm:text-[16px]">
-              Start with serial control in R1, move into Move contracts and real-time transport, and finish with the
-              complete rental-platform capstone in R10. The simulator stays separate so the lessons stay readable.
-            </p>
+    <div className="flex h-full flex-col overflow-y-auto">
+      {/* Hero */}
+      <section className="border-b border-gray-200 bg-white px-6 pb-20 pt-16 lg:px-12">
+        <div className="text-center">
+          <h1 className="text-[3rem] font-medium leading-[0.95] tracking-[-0.04em] text-black sm:text-[4.5rem] lg:text-[5.5rem]">
+            Blockchain robotics,<br />built on Sui.
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-[17px] leading-7 text-gray-500">
+            Learn the full R1-R10 robotics track in one workspace. Every robot action is a real
+            Sui testnet transaction — no hardware needed.
+          </p>
 
-            <div className="mt-6 flex flex-wrap gap-2.5">
-              <Link
-                href="/module/R1"
-                className="inline-flex items-center gap-2 rounded-full border border-[#c9def1] bg-white px-4 py-2.5 text-[13px] font-medium text-[#17324d] transition hover:border-[#9fc9ef]"
-              >
-                Start R1
-                <ArrowRightIcon className="h-4 w-4" />
-              </Link>
-              <Link
-                href="/modules"
-                className="inline-flex items-center gap-2 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-4 py-2.5 text-[13px] font-medium text-[#5d7893] transition hover:border-[#bfd6ea]"
-              >
-                Browse all lessons
-              </Link>
-              <Link
-                href="/playground"
-                className="inline-flex items-center gap-2 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-4 py-2.5 text-[13px] font-medium text-[#5d7893] transition hover:border-[#bfd6ea]"
-              >
-                Open playground
-              </Link>
-            </div>
-
-            <div className="mt-6 flex flex-wrap gap-2">
-              {PHASES.map(({ category, meta, modules }) => (
-                <div
-                  key={category}
-                  className="inline-flex items-center gap-2 rounded-full border border-[#d7e6f4] bg-[#fbfdff] px-3 py-2 text-[11px] text-[#5d7893]"
-                >
-                  <span className="font-brand text-[11px] font-medium text-[#17324d]">{meta.eyebrow}</span>
-                  <span>{category}</span>
-                  <span className="text-[#8ca2b8]">·</span>
-                  <span>{modules.length} lessons</span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="surface-muted rounded-[24px] p-4">
-            <div className="lesson-eyebrow">At a glance</div>
-
-            <div className="mt-3 grid gap-2 sm:grid-cols-3 lg:grid-cols-1">
-              <div className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
-                <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Track length</div>
-                <div className="mt-1 text-[18px] font-medium tracking-[-0.04em] text-[#17324d]">{MODULES.length}</div>
-                <div className="mt-1 text-[12px] text-[#6f8ba6]">sequenced lessons</div>
-              </div>
-              <div className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
-                <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Curriculum shape</div>
-                <div className="mt-1 text-[18px] font-medium tracking-[-0.04em] text-[#17324d]">{CATEGORY_ORDER.length}</div>
-                <div className="mt-1 text-[12px] text-[#6f8ba6]">phases</div>
-              </div>
-              <div className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
-                <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Build mode</div>
-                <div className="mt-1 text-[18px] font-medium tracking-[-0.04em] text-[#17324d]">Sim</div>
-                <div className="mt-1 text-[12px] text-[#6f8ba6]">simulator-first flow</div>
-              </div>
-            </div>
-
-            <div className="mt-4 space-y-2">
-              {PHASES.map(({ category, meta, modules }) => (
-                <div key={category} className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <div className="font-brand text-[14px] font-medium text-[#17324d]">{category}</div>
-                      <div className="mt-1 text-[12px] text-[#6f8ba6]">{meta.eyebrow}</div>
-                    </div>
-                    <div className="inline-flex items-center gap-1.5 text-[11px] text-[#6f8ba6]">
-                      <ClockIcon className="h-3.5 w-3.5" />
-                      {modules.length}
-                    </div>
-                  </div>
-                  <p className="mt-2 text-[12px] leading-5 text-[#6f8ba6]">{meta.description}</p>
-                </div>
-              ))}
-            </div>
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
+            <Link
+              href="/playground"
+              className="inline-flex items-center gap-2 rounded-full bg-[#4da2ff] px-6 py-3 text-[14px] font-medium text-white transition hover:bg-[#3b8de6]"
+            >
+              Open playground
+            </Link>
+            <Link
+              href="/module/R1"
+              className="inline-flex items-center gap-2 rounded-full border border-gray-300 bg-white px-6 py-3 text-[14px] font-medium text-black transition hover:border-gray-400"
+            >
+              Start R1
+              <ArrowRightIcon className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/modules"
+              className="inline-flex items-center gap-2 rounded-full border border-gray-300 bg-white px-6 py-3 text-[14px] font-medium text-black transition hover:border-gray-400"
+            >
+              Browse lessons
+            </Link>
           </div>
         </div>
       </section>
 
-      <section className="surface-panel px-4 py-4 sm:px-5 lg:px-6">
-        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+      {/* Two-column features */}
+      <section className="border-b border-gray-200 bg-white">
+        <div className="grid lg:grid-cols-2 lg:divide-x lg:divide-gray-200">
+          <div className="px-6 py-16 lg:px-12">
+            <div className="lesson-eyebrow">The simulator</div>
+            <h2 className="mt-4 text-[2rem] font-medium leading-[1.05] tracking-[-0.03em] text-black sm:text-[2.6rem]">
+              Why learners use SuiBotics
+            </h2>
+          </div>
+          <div className="px-6 py-16 lg:px-12">
+            <div className="lesson-eyebrow">On-chain</div>
+            <h2 className="mt-4 text-[2rem] font-medium leading-[1.05] tracking-[-0.03em] text-black sm:text-[2.6rem]">
+              How every action hits the chain
+            </h2>
+          </div>
+        </div>
+
+        <div className="grid lg:grid-cols-2">
+          {FEATURES_LEFT.map((f, i) => (
+            <div key={f.title} className={`border-t border-gray-200 px-6 py-6 lg:px-12 ${i % 2 === 1 ? 'lg:border-l' : ''}`}>
+              <div className="flex items-start gap-3">
+                <span className="mt-1.5 h-[10px] w-[10px] shrink-0 rounded-[2px] bg-[#4da2ff]" />
+                <div>
+                  <h3 className="text-[16px] font-medium text-black">{f.title}</h3>
+                  <p className="mt-1.5 text-[14px] leading-6 text-gray-500">{f.desc}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+          {FEATURES_RIGHT.map((f, i) => (
+            <div key={f.title} className={`border-t border-gray-200 px-6 py-6 lg:px-12 ${i % 2 === 0 ? 'lg:border-l' : ''}`}>
+              <div className="flex items-start gap-3">
+                <span className="mt-1.5 h-[10px] w-[10px] shrink-0 rounded-[2px] bg-[#4da2ff]" />
+                <div>
+                  <h3 className="text-[16px] font-medium text-black">{f.title}</h3>
+                  <p className="mt-1.5 text-[14px] leading-6 text-gray-500">{f.desc}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Stats bar */}
+      <section className="border-b border-gray-200 bg-[#1a1a1a]">
+        <div className="grid grid-cols-2 divide-x divide-white/10 lg:grid-cols-4">
+          <div className="px-6 py-8 text-center">
+            <div className="text-[2.5rem] font-medium tracking-[-0.03em] text-white">{MODULES.length}</div>
+            <div className="mt-1 text-[13px] text-white/50">Sequenced lessons</div>
+          </div>
+          <div className="px-6 py-8 text-center">
+            <div className="text-[2.5rem] font-medium tracking-[-0.03em] text-white">{PHASES.length}</div>
+            <div className="mt-1 text-[13px] text-white/50">Curriculum phases</div>
+          </div>
+          <div className="px-6 py-8 text-center">
+            <div className="text-[2.5rem] font-medium tracking-[-0.03em] text-white">12</div>
+            <div className="mt-1 text-[13px] text-white/50">On-chain actions</div>
+          </div>
+          <div className="px-6 py-8 text-center">
+            <div className="text-[2.5rem] font-medium tracking-[-0.03em] text-[#4da2ff]">Testnet</div>
+            <div className="mt-1 text-[13px] text-white/50">Deployed network</div>
+          </div>
+        </div>
+      </section>
+
+      {/* Curriculum phases */}
+      <section className="border-b border-gray-200 bg-white px-6 py-16 lg:px-12">
+        <div className="text-center">
+          <div className="lesson-eyebrow mx-auto w-fit">Curriculum</div>
+          <h2 className="mt-4 text-[2rem] font-medium tracking-[-0.03em] text-black sm:text-[2.6rem]">
+            Four phases, ten lessons.
+          </h2>
+        </div>
+
+        <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {PHASES.map(({ category, meta, modules }) => (
+            <div key={category} className="rounded-xl bg-gray-50 p-5">
+              <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-gray-400">{meta.eyebrow}</div>
+              <h3 className="mt-2 text-[20px] font-medium tracking-[-0.02em] text-black">{category}</h3>
+              <p className="mt-2 text-[13px] leading-5 text-gray-500">{meta.description}</p>
+              <div className="mt-4 text-[12px] font-medium text-[#4da2ff]">{modules.length} lessons</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* All modules grid */}
+      <section className="bg-white px-6 py-16 lg:px-12">
+        <div className="mb-8 flex items-end justify-between">
           <div>
-            <div className="lesson-eyebrow">Curriculum map</div>
-            <h2 className="mt-1 text-[1.5rem] font-medium tracking-[-0.05em] text-[#011829] sm:text-[1.85rem]">
+            <div className="lesson-eyebrow">All lessons</div>
+            <h2 className="mt-3 text-[2rem] font-medium tracking-[-0.03em] text-black sm:text-[2.2rem]">
               Every lesson, in order.
             </h2>
           </div>
-          <Link href="/modules" className="text-[12px] font-medium text-[#1d79e6]">
-            Open lesson index
+          <Link href="/modules" className="text-[13px] font-medium text-[#4da2ff] hover:underline">
+            View all
           </Link>
         </div>
 
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
           {MODULES.map((module) => {
             const phase = PHASES.find((entry) => entry.category === module.category);
 
@@ -119,28 +164,28 @@ export default function HomePage() {
               <Link
                 key={module.id}
                 href={`/module/${module.id}`}
-                className="group rounded-[18px] border border-[#d7e6f4] bg-white px-4 py-4 transition hover:border-[#bfd6ea] hover:shadow-[0_10px_22px_rgba(1,24,41,0.05)]"
+                className="group rounded-xl border border-gray-200 bg-white p-5 transition hover:border-gray-300 hover:shadow-sm"
               >
-                <div className="flex items-start justify-between gap-3">
+                <div className="flex items-start justify-between gap-2">
                   <div className="min-w-0">
-                    <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">{module.id}</div>
-                    <div className="mt-1 text-[18px] font-medium tracking-[-0.045em] text-[#011829]">{module.title}</div>
-                    <div className="mt-1 text-[12px] leading-5 text-[#6f8ba6]">{module.subtitle}</div>
+                    <div className="text-[11px] font-medium uppercase tracking-[0.1em] text-gray-400">{module.id}</div>
+                    <div className="mt-1 text-[17px] font-medium tracking-[-0.02em] text-black">{module.title}</div>
+                    <div className="mt-0.5 text-[13px] text-gray-500">{module.subtitle}</div>
                   </div>
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] text-[11px] font-medium text-[#17324d]">
+                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gray-100 text-[11px] font-medium text-gray-600">
                     {getModuleOrder(module.id)}
                   </div>
                 </div>
 
-                <p className="mt-3 text-[13px] leading-5 text-[#5d7893]">{module.summary}</p>
+                <p className="mt-3 text-[14px] leading-6 text-gray-500">{module.summary}</p>
 
-                <div className="mt-4 flex items-center justify-between gap-3 border-t border-[#edf4fb] pt-3">
-                  <div className="text-[11px] text-[#6f8ba6]">
-                    {phase?.meta.eyebrow} · {module.category}
+                <div className="mt-4 flex items-center justify-between border-t border-gray-100 pt-3">
+                  <div className="text-[11px] text-gray-400">
+                    {phase?.meta.eyebrow}
                   </div>
-                  <div className="inline-flex items-center gap-1.5 text-[12px] font-medium text-[#17324d]">
+                  <div className="inline-flex items-center gap-1 text-[13px] font-medium text-black">
                     Open
-                    <ArrowRightIcon className="h-4 w-4 text-[#4DA2FF] transition group-hover:translate-x-1" />
+                    <ArrowRightIcon className="h-3.5 w-3.5 text-[#4da2ff] transition group-hover:translate-x-0.5" />
                   </div>
                 </div>
               </Link>
@@ -148,6 +193,19 @@ export default function HomePage() {
           })}
         </div>
       </section>
+
+      {/* Footer */}
+      <footer className="border-t border-gray-200 bg-[#1a1a1a] px-6 py-8 lg:px-12">
+        <div className="flex items-center justify-between">
+          <div className="text-[13px] text-white/40">
+            Built on Sui testnet
+          </div>
+          <div className="flex gap-4 text-[13px] text-white/40">
+            <Link href="/playground" className="hover:text-white/70">Playground</Link>
+            <Link href="/modules" className="hover:text-white/70">Lessons</Link>
+          </div>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/simulator/src/app/page.tsx
+++ b/simulator/src/app/page.tsx
@@ -1,0 +1,153 @@
+import Link from 'next/link';
+import { ArrowRightIcon, ClockIcon } from '@/components/icons';
+import { CATEGORY_ORDER, getCurriculumPhases, getModuleOrder, MODULES } from '@/lib/modules';
+
+const PHASES = getCurriculumPhases(MODULES);
+
+export default function HomePage() {
+  return (
+    <div className="flex h-full flex-col overflow-y-auto pb-4">
+      <section className="surface-panel mb-3 px-4 py-5 sm:px-6 lg:px-8 lg:py-7">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_330px] lg:gap-8">
+          <div className="max-w-5xl">
+            <div className="lesson-eyebrow">Sui robotics playground</div>
+            <h1 className="mt-3 max-w-4xl text-[2.45rem] font-medium leading-[0.94] tracking-[-0.075em] text-[#011829] sm:text-[3.35rem] lg:text-[4.6rem]">
+              Learn the full R1-R10 robotics track in one clean workspace.
+            </h1>
+            <p className="mt-5 max-w-2xl text-[15px] leading-7 text-[#5d7893] sm:text-[16px]">
+              Start with serial control in R1, move into Move contracts and real-time transport, and finish with the
+              complete rental-platform capstone in R10. The simulator stays separate so the lessons stay readable.
+            </p>
+
+            <div className="mt-6 flex flex-wrap gap-2.5">
+              <Link
+                href="/module/R1"
+                className="inline-flex items-center gap-2 rounded-full border border-[#c9def1] bg-white px-4 py-2.5 text-[13px] font-medium text-[#17324d] transition hover:border-[#9fc9ef]"
+              >
+                Start R1
+                <ArrowRightIcon className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/modules"
+                className="inline-flex items-center gap-2 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-4 py-2.5 text-[13px] font-medium text-[#5d7893] transition hover:border-[#bfd6ea]"
+              >
+                Browse all lessons
+              </Link>
+              <Link
+                href="/playground"
+                className="inline-flex items-center gap-2 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-4 py-2.5 text-[13px] font-medium text-[#5d7893] transition hover:border-[#bfd6ea]"
+              >
+                Open playground
+              </Link>
+            </div>
+
+            <div className="mt-6 flex flex-wrap gap-2">
+              {PHASES.map(({ category, meta, modules }) => (
+                <div
+                  key={category}
+                  className="inline-flex items-center gap-2 rounded-full border border-[#d7e6f4] bg-[#fbfdff] px-3 py-2 text-[11px] text-[#5d7893]"
+                >
+                  <span className="font-brand text-[11px] font-medium text-[#17324d]">{meta.eyebrow}</span>
+                  <span>{category}</span>
+                  <span className="text-[#8ca2b8]">·</span>
+                  <span>{modules.length} lessons</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="surface-muted rounded-[24px] p-4">
+            <div className="lesson-eyebrow">At a glance</div>
+
+            <div className="mt-3 grid gap-2 sm:grid-cols-3 lg:grid-cols-1">
+              <div className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
+                <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Track length</div>
+                <div className="mt-1 text-[18px] font-medium tracking-[-0.04em] text-[#17324d]">{MODULES.length}</div>
+                <div className="mt-1 text-[12px] text-[#6f8ba6]">sequenced lessons</div>
+              </div>
+              <div className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
+                <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Curriculum shape</div>
+                <div className="mt-1 text-[18px] font-medium tracking-[-0.04em] text-[#17324d]">{CATEGORY_ORDER.length}</div>
+                <div className="mt-1 text-[12px] text-[#6f8ba6]">phases</div>
+              </div>
+              <div className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
+                <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">Build mode</div>
+                <div className="mt-1 text-[18px] font-medium tracking-[-0.04em] text-[#17324d]">Sim</div>
+                <div className="mt-1 text-[12px] text-[#6f8ba6]">simulator-first flow</div>
+              </div>
+            </div>
+
+            <div className="mt-4 space-y-2">
+              {PHASES.map(({ category, meta, modules }) => (
+                <div key={category} className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-brand text-[14px] font-medium text-[#17324d]">{category}</div>
+                      <div className="mt-1 text-[12px] text-[#6f8ba6]">{meta.eyebrow}</div>
+                    </div>
+                    <div className="inline-flex items-center gap-1.5 text-[11px] text-[#6f8ba6]">
+                      <ClockIcon className="h-3.5 w-3.5" />
+                      {modules.length}
+                    </div>
+                  </div>
+                  <p className="mt-2 text-[12px] leading-5 text-[#6f8ba6]">{meta.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="surface-panel px-4 py-4 sm:px-5 lg:px-6">
+        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <div className="lesson-eyebrow">Curriculum map</div>
+            <h2 className="mt-1 text-[1.5rem] font-medium tracking-[-0.05em] text-[#011829] sm:text-[1.85rem]">
+              Every lesson, in order.
+            </h2>
+          </div>
+          <Link href="/modules" className="text-[12px] font-medium text-[#1d79e6]">
+            Open lesson index
+          </Link>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+          {MODULES.map((module) => {
+            const phase = PHASES.find((entry) => entry.category === module.category);
+
+            return (
+              <Link
+                key={module.id}
+                href={`/module/${module.id}`}
+                className="group rounded-[18px] border border-[#d7e6f4] bg-white px-4 py-4 transition hover:border-[#bfd6ea] hover:shadow-[0_10px_22px_rgba(1,24,41,0.05)]"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">{module.id}</div>
+                    <div className="mt-1 text-[18px] font-medium tracking-[-0.045em] text-[#011829]">{module.title}</div>
+                    <div className="mt-1 text-[12px] leading-5 text-[#6f8ba6]">{module.subtitle}</div>
+                  </div>
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] text-[11px] font-medium text-[#17324d]">
+                    {getModuleOrder(module.id)}
+                  </div>
+                </div>
+
+                <p className="mt-3 text-[13px] leading-5 text-[#5d7893]">{module.summary}</p>
+
+                <div className="mt-4 flex items-center justify-between gap-3 border-t border-[#edf4fb] pt-3">
+                  <div className="text-[11px] text-[#6f8ba6]">
+                    {phase?.meta.eyebrow} · {module.category}
+                  </div>
+                  <div className="inline-flex items-center gap-1.5 text-[12px] font-medium text-[#17324d]">
+                    Open
+                    <ArrowRightIcon className="h-4 w-4 text-[#4DA2FF] transition group-hover:translate-x-1" />
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/simulator/src/app/playground/page.tsx
+++ b/simulator/src/app/playground/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import Link from 'next/link';
+import ControlPanel from '@/components/ControlPanel';
+import RobotViewport from '@/components/RobotViewport';
+import { ArrowRightIcon, ClockIcon, SuiDropletIcon } from '@/components/icons';
+import { MODULES } from '@/lib/modules';
+
+export default function PlaygroundPage() {
+  return (
+    <div className="flex h-full flex-col overflow-y-auto pb-4">
+      <section className="surface-panel mb-3 px-4 py-5 sm:px-5 lg:px-6">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px]">
+          <div className="max-w-4xl">
+            <div className="inline-flex items-center gap-2 rounded-full border border-[#d7e6f4] bg-white px-3 py-1.5 text-[11px] text-[#5d7893]">
+              <SuiDropletIcon className="h-4 w-4 text-[#4DA2FF]" />
+              Sui brand surface
+            </div>
+            <div className="lesson-eyebrow mt-4">Dedicated simulator</div>
+            <h1 className="mt-3 max-w-3xl text-[2.2rem] font-medium leading-[0.96] tracking-[-0.07em] text-[#011829] sm:text-[3rem]">
+              Drive the Unitree GO1 in a clean, Sui-styled sandbox.
+            </h1>
+            <p className="mt-4 max-w-2xl text-[14px] leading-7 text-[#5d7893] sm:text-[15px]">
+              This page is the focused control surface for the robot itself. Keep the lessons separate, use the same
+              simulator state across the R1-R10 track, and test posture, movement, and quick command flows here.
+            </p>
+
+            <div className="mt-5 flex flex-wrap gap-2">
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-2 text-[11px] text-[#5d7893]">
+                <ClockIcon className="h-3.5 w-3.5 text-[#4DA2FF]" />
+                {MODULES.length} lessons share this simulator
+              </span>
+              <span className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-2 text-[11px] text-[#5d7893]">
+                Sea / Ocean / Aqua palette
+              </span>
+            </div>
+          </div>
+
+          <div className="surface-muted rounded-[22px] p-4">
+            <div className="lesson-eyebrow">Playground route</div>
+            <div className="mt-2 text-[15px] font-medium tracking-[-0.03em] text-[#011829]">Use the simulator, then jump back into lessons.</div>
+            <div className="mt-3 space-y-2">
+              <Link
+                href="/module/R1"
+                className="inline-flex w-full items-center justify-between rounded-[14px] border border-[#c9def1] bg-white px-4 py-3 text-[13px] font-medium text-[#17324d] transition hover:border-[#9fc9ef]"
+              >
+                Start with R1
+                <ArrowRightIcon className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/modules"
+                className="inline-flex w-full items-center justify-between rounded-[14px] border border-[#d7e6f4] bg-white px-4 py-3 text-[13px] font-medium text-[#5d7893] transition hover:border-[#bfd6ea]"
+              >
+                Back to lessons
+                <ArrowRightIcon className="h-4 w-4" />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid items-start gap-3 xl:grid-cols-[minmax(0,1fr)_288px]">
+        <RobotViewport />
+        <ControlPanel />
+      </section>
+    </div>
+  );
+}

--- a/simulator/src/app/playground/page.tsx
+++ b/simulator/src/app/playground/page.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import ControlPanel from '@/components/ControlPanel';
 import RobotViewport from '@/components/RobotViewport';
-import { ArrowRightIcon, ClockIcon, SuiDropletIcon } from '@/components/icons';
+import { ArrowRightIcon, ClockIcon } from '@/components/icons';
 import { MODULES } from '@/lib/modules';
 
 export default function PlaygroundPage() {
@@ -12,13 +12,9 @@ export default function PlaygroundPage() {
       <section className="surface-panel mb-3 px-4 py-5 sm:px-5 lg:px-6">
         <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px]">
           <div className="max-w-4xl">
-            <div className="inline-flex items-center gap-2 rounded-full border border-[#d7e6f4] bg-white px-3 py-1.5 text-[11px] text-[#5d7893]">
-              <SuiDropletIcon className="h-4 w-4 text-[#4DA2FF]" />
-              Sui brand surface
-            </div>
-            <div className="lesson-eyebrow mt-4">Dedicated simulator</div>
+            <div className="lesson-eyebrow">Dedicated simulator</div>
             <h1 className="mt-3 max-w-3xl text-[2.2rem] font-medium leading-[0.96] tracking-[-0.07em] text-[#011829] sm:text-[3rem]">
-              Drive the Unitree GO1 in a clean, Sui-styled sandbox.
+              Drive the Unitree GO1 robot simulator.
             </h1>
             <p className="mt-4 max-w-2xl text-[14px] leading-7 text-[#5d7893] sm:text-[15px]">
               This page is the focused control surface for the robot itself. Keep the lessons separate, use the same

--- a/simulator/src/app/playground/page.tsx
+++ b/simulator/src/app/playground/page.tsx
@@ -1,62 +1,116 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import ControlPanel from '@/components/ControlPanel';
 import RobotViewport from '@/components/RobotViewport';
 import Terminal from '@/components/Terminal';
 import { ArrowRightIcon } from '@/components/icons';
 import { useOnChainAction } from '@/hooks/useOnChainAction';
+import { MODULES, MODULE_CONCEPTS, CATEGORY_META } from '@/lib/modules';
 
 export default function PlaygroundPage() {
   const { isWalletConnected } = useOnChainAction();
+  const [activeModule, setActiveModule] = useState<string | null>(null);
+
+  const selected = activeModule ? MODULES.find((m) => m.id === activeModule) : null;
+  const concepts = activeModule ? MODULE_CONCEPTS[activeModule] ?? [] : [];
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto pb-4">
-      <section className="mb-3 rounded-2xl border border-gray-200 bg-white px-4 py-5 sm:px-5 lg:px-6">
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-          <div className="max-w-4xl">
-            <div className="lesson-eyebrow">Simulator</div>
-            <h1 className="mt-3 max-w-3xl text-[2.2rem] font-medium leading-[0.96] tracking-[-0.04em] text-black sm:text-[3rem]">
-              Drive the Unitree GO1.
-            </h1>
-            <p className="mt-4 max-w-2xl text-[14px] leading-7 text-gray-500 sm:text-[15px]">
-              Connect your Sui wallet to control the robot. Every action is a real
-              on-chain transaction signed by you.
-            </p>
-          </div>
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Top bar — lesson selector */}
+      <div className="flex items-center gap-2 overflow-x-auto border-b border-gray-200 bg-white px-4 py-2">
+        <button
+          onClick={() => setActiveModule(null)}
+          className={`shrink-0 rounded-lg px-3 py-1.5 text-[12px] font-medium transition ${
+            !activeModule ? 'bg-black text-white' : 'text-gray-500 hover:bg-gray-100'
+          }`}
+        >
+          Free Play
+        </button>
+        {MODULES.map((m) => (
+          <button
+            key={m.id}
+            onClick={() => setActiveModule(m.id)}
+            className={`shrink-0 rounded-lg px-3 py-1.5 text-[12px] font-medium transition ${
+              activeModule === m.id ? 'bg-black text-white' : 'text-gray-500 hover:bg-gray-100'
+            }`}
+          >
+            {m.id}
+          </button>
+        ))}
+      </div>
 
-          <div className="rounded-xl bg-gray-50 p-4">
-            <div className="text-[12px] font-medium uppercase tracking-[0.1em] text-gray-400">Quick links</div>
-            <div className="mt-3 space-y-2">
-              <Link
-                href="/module/R1"
-                className="inline-flex w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 text-[13px] font-medium text-black transition hover:border-gray-300"
-              >
-                Start with R1
-                <ArrowRightIcon className="h-4 w-4 text-[#4da2ff]" />
-              </Link>
-              <Link
-                href="/modules"
-                className="inline-flex w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 text-[13px] font-medium text-gray-500 transition hover:border-gray-300"
-              >
-                Back to lessons
-                <ArrowRightIcon className="h-4 w-4" />
-              </Link>
-            </div>
+      {/* Lesson context bar */}
+      {selected && (
+        <div className="flex items-center justify-between gap-4 border-b border-gray-100 bg-gray-50 px-4 py-2.5">
+          <div className="flex items-center gap-3 overflow-hidden">
+            <span className="shrink-0 text-[11px] font-medium uppercase tracking-[0.1em] text-gray-400">
+              {CATEGORY_META[selected.category]?.eyebrow}
+            </span>
+            <span className="truncate text-[13px] font-medium text-black">
+              {selected.id}: {selected.title}
+            </span>
+            <span className="hidden truncate text-[12px] text-gray-400 sm:inline">
+              {selected.subtitle}
+            </span>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {concepts.slice(0, 2).map((c) => (
+              <span key={c} className="hidden rounded bg-white px-2 py-0.5 text-[9px] font-medium text-gray-500 lg:inline">
+                {c}
+              </span>
+            ))}
+            <Link
+              href={`/module/${selected.id}`}
+              className="inline-flex items-center gap-1 rounded-lg bg-white px-3 py-1.5 text-[11px] font-medium text-[#4da2ff] shadow-sm transition hover:shadow"
+            >
+              Open lesson
+              <ArrowRightIcon className="h-3 w-3" />
+            </Link>
           </div>
         </div>
-      </section>
+      )}
 
+      {/* Main content */}
       {isWalletConnected ? (
-        <>
-          <section className="grid items-start gap-3 xl:grid-cols-[minmax(0,1fr)_288px]">
-            <RobotViewport />
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-3">
+          {/* Lesson description card */}
+          {selected && (
+            <div className="mb-3 rounded-xl border border-gray-200 bg-white px-4 py-3">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="text-[13px] leading-5 text-gray-500">{selected.summary}</p>
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {selected.focus.map((f) => (
+                      <span key={f} className="rounded bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">{f}</span>
+                    ))}
+                  </div>
+                </div>
+                <div className="shrink-0 text-right">
+                  <div className="text-[10px] font-medium text-gray-400">{selected.time}</div>
+                  <div className="mt-0.5 text-[10px] text-gray-300">{selected.artifact}</div>
+                </div>
+              </div>
+              {selected.simScript && (
+                <div className="mt-2 rounded-lg bg-gray-50 px-3 py-2">
+                  <div className="text-[9px] font-medium uppercase tracking-[0.1em] text-gray-400">Run command</div>
+                  <code className="mt-0.5 block font-mono-ui text-[11px] text-gray-600">{selected.simScript}</code>
+                </div>
+              )}
+            </div>
+          )}
+
+          <section className="grid min-h-0 flex-1 items-start gap-3 xl:grid-cols-[minmax(0,1fr)_288px]">
+            <div className="flex min-h-0 flex-col gap-3">
+              <RobotViewport />
+              <Terminal />
+            </div>
             <ControlPanel />
           </section>
-          <Terminal />
-        </>
+        </div>
       ) : (
-        <section className="flex flex-1 items-center justify-center rounded-2xl border border-gray-200 bg-white">
+        <div className="flex flex-1 items-center justify-center bg-white">
           <div className="px-6 py-20 text-center">
             <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-gray-100">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-7 w-7 text-gray-400">
@@ -72,11 +126,18 @@ export default function PlaygroundPage() {
               The robot simulator requires a connected Sui wallet. Every action you
               perform is signed and submitted as a real testnet transaction.
             </p>
-            <div className="mt-6 text-[13px] text-gray-400">
-              Use the Connect wallet button in the top right
+            <div className="mt-8 flex flex-wrap justify-center gap-2">
+              {MODULES.slice(0, 5).map((m) => (
+                <span key={m.id} className="rounded-full bg-gray-50 px-3 py-1.5 text-[11px] text-gray-400">
+                  {m.id}: {m.title}
+                </span>
+              ))}
+              <span className="rounded-full bg-gray-50 px-3 py-1.5 text-[11px] text-gray-400">
+                +{MODULES.length - 5} more
+              </span>
             </div>
           </div>
-        </section>
+        </div>
       )}
     </div>
   );

--- a/simulator/src/app/playground/page.tsx
+++ b/simulator/src/app/playground/page.tsx
@@ -3,9 +3,13 @@
 import Link from 'next/link';
 import ControlPanel from '@/components/ControlPanel';
 import RobotViewport from '@/components/RobotViewport';
+import Terminal from '@/components/Terminal';
 import { ArrowRightIcon } from '@/components/icons';
+import { useOnChainAction } from '@/hooks/useOnChainAction';
 
 export default function PlaygroundPage() {
+  const { isWalletConnected } = useOnChainAction();
+
   return (
     <div className="flex h-full flex-col overflow-y-auto pb-4">
       <section className="mb-3 rounded-2xl border border-gray-200 bg-white px-4 py-5 sm:px-5 lg:px-6">
@@ -16,8 +20,8 @@ export default function PlaygroundPage() {
               Drive the Unitree GO1.
             </h1>
             <p className="mt-4 max-w-2xl text-[14px] leading-7 text-gray-500 sm:text-[15px]">
-              The focused control surface for the robot. Every action is an on-chain
-              transaction when your wallet is connected.
+              Connect your Sui wallet to control the robot. Every action is a real
+              on-chain transaction signed by you.
             </p>
           </div>
 
@@ -43,10 +47,37 @@ export default function PlaygroundPage() {
         </div>
       </section>
 
-      <section className="grid items-start gap-3 xl:grid-cols-[minmax(0,1fr)_288px]">
-        <RobotViewport />
-        <ControlPanel />
-      </section>
+      {isWalletConnected ? (
+        <>
+          <section className="grid items-start gap-3 xl:grid-cols-[minmax(0,1fr)_288px]">
+            <RobotViewport />
+            <ControlPanel />
+          </section>
+          <Terminal />
+        </>
+      ) : (
+        <section className="flex flex-1 items-center justify-center rounded-2xl border border-gray-200 bg-white">
+          <div className="px-6 py-20 text-center">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-gray-100">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-7 w-7 text-gray-400">
+                <rect x="2" y="6" width="20" height="14" rx="3" />
+                <path d="M2 10h20" />
+                <path d="M6 14h.01" />
+              </svg>
+            </div>
+            <h2 className="mt-5 text-[1.4rem] font-medium tracking-[-0.02em] text-black">
+              Connect your wallet to begin
+            </h2>
+            <p className="mx-auto mt-2 max-w-sm text-[14px] leading-6 text-gray-500">
+              The robot simulator requires a connected Sui wallet. Every action you
+              perform is signed and submitted as a real testnet transaction.
+            </p>
+            <div className="mt-6 text-[13px] text-gray-400">
+              Use the Connect wallet button in the top right
+            </div>
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/simulator/src/app/playground/page.tsx
+++ b/simulator/src/app/playground/page.tsx
@@ -3,49 +3,37 @@
 import Link from 'next/link';
 import ControlPanel from '@/components/ControlPanel';
 import RobotViewport from '@/components/RobotViewport';
-import { ArrowRightIcon, ClockIcon } from '@/components/icons';
-import { MODULES } from '@/lib/modules';
+import { ArrowRightIcon } from '@/components/icons';
 
 export default function PlaygroundPage() {
   return (
     <div className="flex h-full flex-col overflow-y-auto pb-4">
-      <section className="surface-panel mb-3 px-4 py-5 sm:px-5 lg:px-6">
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px]">
+      <section className="mb-3 rounded-2xl border border-gray-200 bg-white px-4 py-5 sm:px-5 lg:px-6">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
           <div className="max-w-4xl">
-            <div className="lesson-eyebrow">Dedicated simulator</div>
-            <h1 className="mt-3 max-w-3xl text-[2.2rem] font-medium leading-[0.96] tracking-[-0.07em] text-[#011829] sm:text-[3rem]">
-              Drive the Unitree GO1 robot simulator.
+            <div className="lesson-eyebrow">Simulator</div>
+            <h1 className="mt-3 max-w-3xl text-[2.2rem] font-medium leading-[0.96] tracking-[-0.04em] text-black sm:text-[3rem]">
+              Drive the Unitree GO1.
             </h1>
-            <p className="mt-4 max-w-2xl text-[14px] leading-7 text-[#5d7893] sm:text-[15px]">
-              This page is the focused control surface for the robot itself. Keep the lessons separate, use the same
-              simulator state across the R1-R10 track, and test posture, movement, and quick command flows here.
+            <p className="mt-4 max-w-2xl text-[14px] leading-7 text-gray-500 sm:text-[15px]">
+              The focused control surface for the robot. Every action is an on-chain
+              transaction when your wallet is connected.
             </p>
-
-            <div className="mt-5 flex flex-wrap gap-2">
-              <span className="inline-flex items-center gap-1.5 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-2 text-[11px] text-[#5d7893]">
-                <ClockIcon className="h-3.5 w-3.5 text-[#4DA2FF]" />
-                {MODULES.length} lessons share this simulator
-              </span>
-              <span className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-2 text-[11px] text-[#5d7893]">
-                Sea / Ocean / Aqua palette
-              </span>
-            </div>
           </div>
 
-          <div className="surface-muted rounded-[22px] p-4">
-            <div className="lesson-eyebrow">Playground route</div>
-            <div className="mt-2 text-[15px] font-medium tracking-[-0.03em] text-[#011829]">Use the simulator, then jump back into lessons.</div>
+          <div className="rounded-xl bg-gray-50 p-4">
+            <div className="text-[12px] font-medium uppercase tracking-[0.1em] text-gray-400">Quick links</div>
             <div className="mt-3 space-y-2">
               <Link
                 href="/module/R1"
-                className="inline-flex w-full items-center justify-between rounded-[14px] border border-[#c9def1] bg-white px-4 py-3 text-[13px] font-medium text-[#17324d] transition hover:border-[#9fc9ef]"
+                className="inline-flex w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 text-[13px] font-medium text-black transition hover:border-gray-300"
               >
                 Start with R1
-                <ArrowRightIcon className="h-4 w-4" />
+                <ArrowRightIcon className="h-4 w-4 text-[#4da2ff]" />
               </Link>
               <Link
                 href="/modules"
-                className="inline-flex w-full items-center justify-between rounded-[14px] border border-[#d7e6f4] bg-white px-4 py-3 text-[13px] font-medium text-[#5d7893] transition hover:border-[#bfd6ea]"
+                className="inline-flex w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-3 text-[13px] font-medium text-gray-500 transition hover:border-gray-300"
               >
                 Back to lessons
                 <ArrowRightIcon className="h-4 w-4" />

--- a/simulator/src/components/ControlPanel.tsx
+++ b/simulator/src/components/ControlPanel.tsx
@@ -6,6 +6,7 @@ import { useOnChainAction } from '@/hooks/useOnChainAction';
 import { useOnChainQueue } from '@/hooks/useOnChainQueue';
 import { useSessionTracker } from '@/hooks/useSessionTracker';
 import { useCommandHistory } from '@/hooks/useCommandHistory';
+import { useCookieToken } from '@/hooks/useCookieToken';
 import { ChainIcon, HardwareIcon } from '@/components/icons';
 
 interface CommandButton {
@@ -77,6 +78,7 @@ export default function ControlPanel() {
   const queue = useOnChainQueue();
   const session = useSessionTracker(isWalletConnected, robotState?.commandsExecuted ?? 0);
   const history = useCommandHistory();
+  const cookie = useCookieToken();
   const [showShortcuts, setShowShortcuts] = useState(false);
 
   const currentAction = robotState?.action ?? 'idle';
@@ -147,6 +149,23 @@ export default function ControlPanel() {
           ) : (
             <div className="text-[11px] text-gray-400">Connect wallet for on-chain mode</div>
           )}
+        </Section>
+      )}
+
+      {/* COOKIE Token (R8) */}
+      {isWalletConnected && (
+        <Section title="COOKIE Token (R8)">
+          <div className="grid grid-cols-2 gap-1.5">
+            <Stat label="Balance" value={String(cookie.balance)} />
+            <Stat label="Supply" value="1B" />
+          </div>
+          <button
+            onClick={() => cookie.mint(100)}
+            disabled={cookie.isMinting}
+            className="mt-2 w-full rounded-lg bg-[#4da2ff] px-3 py-2 text-[12px] font-medium text-white transition hover:bg-[#3b8de6] disabled:opacity-50"
+          >
+            {cookie.isMinting ? 'Minting...' : 'Mint 100 COOKIE'}
+          </button>
         </Section>
       )}
 

--- a/simulator/src/components/ControlPanel.tsx
+++ b/simulator/src/components/ControlPanel.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useSimulator } from '@/hooks/useSimulator';
 import { useOnChainAction } from '@/hooks/useOnChainAction';
 import { useOnChainQueue } from '@/hooks/useOnChainQueue';
-import { ChainIcon, ClockIcon, HardwareIcon } from '@/components/icons';
+import { ChainIcon, HardwareIcon } from '@/components/icons';
 
 interface CommandButton {
   code: string;
@@ -81,44 +81,36 @@ export default function ControlPanel() {
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.repeat) {
-        return;
-      }
+      if (event.repeat) return;
 
       const target = event.target;
       if (target instanceof HTMLElement) {
         const tagName = target.tagName.toLowerCase();
-        if (tagName === 'input' || tagName === 'textarea' || target.isContentEditable) {
-          return;
-        }
+        if (tagName === 'input' || tagName === 'textarea' || target.isContentEditable) return;
       }
 
       const key = event.code === 'Space' ? 'Space' : event.key.toUpperCase();
       const shortcut = KEYBOARD_SHORTCUTS.find((entry) => entry.key === key);
-      if (!shortcut) {
-        return;
-      }
+      if (!shortcut) return;
 
       event.preventDefault();
       sendActionWithChain(shortcut.code);
     }
 
     window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
+    return () => window.removeEventListener('keydown', handleKeyDown);
   }, [sendActionWithChain]);
 
   return (
-    <aside className="surface-panel flex h-full min-h-[380px] flex-col overflow-hidden px-4 py-4">
+    <aside className="flex h-full min-h-[380px] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white px-4 py-4">
       <div className="mb-4 flex items-center justify-between gap-3">
         <div>
-          <div className="lesson-eyebrow">Control</div>
-          <h2 className="font-brand mt-1 text-[16px] font-medium tracking-[-0.03em] text-[#011829]">
+          <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-gray-400">Control</div>
+          <h2 className="mt-1 text-[16px] font-medium tracking-[-0.02em] text-black">
             GO1 command surface
           </h2>
         </div>
-        <div className="inline-flex items-center gap-1.5 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+        <div className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1 text-[10px] font-medium text-gray-500">
           Live
         </div>
       </div>
@@ -130,23 +122,23 @@ export default function ControlPanel() {
         <StatusCard label="Battery" value={`${battery.toFixed(0)}%`} />
       </div>
 
-      <div className="mb-4 rounded-[16px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3">
-        <div className="mb-2 flex items-center gap-2 text-[12px] text-[#5d7893]">
-          <HardwareIcon className="h-4 w-4 text-[#4DA2FF]" />
-          Battery envelope
+      <div className="mb-4 rounded-xl bg-gray-50 px-3 py-3">
+        <div className="mb-2 flex items-center gap-2 text-[12px] text-gray-500">
+          <HardwareIcon className="h-4 w-4 text-[#4da2ff]" />
+          Battery
         </div>
-        <div className="h-1.5 w-full overflow-hidden rounded-full bg-white">
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-200">
           <div
-            className="h-full rounded-full bg-[linear-gradient(90deg,#4DA2FF_0%,#1f8f6f_100%)]"
+            className="h-full rounded-full bg-[#4da2ff]"
             style={{ width: `${battery}%` }}
           />
         </div>
       </div>
 
       {isOnChainConfigured && (
-        <div className="mb-4 rounded-[16px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3">
-          <div className="mb-2 flex items-center gap-2 text-[12px] text-[#5d7893]">
-            <ChainIcon className="h-4 w-4 text-[#4DA2FF]" />
+        <div className="mb-4 rounded-xl bg-gray-50 px-3 py-3">
+          <div className="mb-2 flex items-center gap-2 text-[12px] text-gray-500">
+            <ChainIcon className="h-4 w-4 text-[#4da2ff]" />
             On-chain status
           </div>
           {isWalletConnected ? (
@@ -157,7 +149,7 @@ export default function ControlPanel() {
               <StatusCard label="Pending" value={String(pendingTxCount)} />
             </div>
           ) : (
-            <div className="text-[11px] text-[#6f8ba6]">
+            <div className="text-[11px] text-gray-400">
               Connect wallet for on-chain mode
             </div>
           )}
@@ -166,8 +158,8 @@ export default function ControlPanel() {
 
       <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
         {COMMAND_GROUPS.map((group) => (
-          <section key={group.title} className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
-            <div className="mb-2 text-[11px] uppercase tracking-[0.18em] text-[#6f8ba6]">{group.title}</div>
+          <section key={group.title} className="rounded-xl border border-gray-200 bg-white px-3 py-3">
+            <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.12em] text-gray-400">{group.title}</div>
             <div className="grid grid-cols-2 gap-2">
               {group.commands.map((command) => {
                 const active = currentAction === command.code;
@@ -175,10 +167,10 @@ export default function ControlPanel() {
                   <button
                     key={command.code}
                     onClick={() => sendActionWithChain(command.code)}
-                    className={`rounded-[14px] border px-3 py-2 text-left text-[12px] font-medium transition ${
+                    className={`rounded-lg border px-3 py-2 text-left text-[12px] font-medium transition ${
                       active
-                        ? 'border-[#c9def1] bg-[#f4f8fc] text-[#17324d]'
-                        : 'border-[#d7e6f4] bg-[#f8fbff] text-[#5d7893] hover:border-[#bfd6ea] hover:bg-white'
+                        ? 'border-[#4da2ff] bg-[#4da2ff]/5 text-black'
+                        : 'border-gray-200 bg-gray-50 text-gray-600 hover:border-gray-300 hover:bg-white'
                     }`}
                   >
                     {command.label}
@@ -190,23 +182,20 @@ export default function ControlPanel() {
         ))}
       </div>
 
-      <div className="mt-4 rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
-        <button onClick={() => setShowShortcuts((value) => !value)} className="flex w-full items-center justify-between">
-          <div className="text-[12px] font-medium text-[#17324d]">Keyboard</div>
-          <span className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+      <div className="mt-4 rounded-xl border border-gray-200 bg-white px-3 py-3">
+        <button onClick={() => setShowShortcuts((v) => !v)} className="flex w-full items-center justify-between">
+          <div className="text-[12px] font-medium text-black">Keyboard</div>
+          <span className="rounded-full bg-gray-100 px-2.5 py-1 text-[10px] font-medium text-gray-500">
             {showShortcuts ? 'Hide' : 'Show'}
           </span>
         </button>
 
         {showShortcuts && (
-          <div className="mt-3 space-y-2">
+          <div className="mt-3 space-y-1.5">
             {KEYBOARD_SHORTCUTS.map((shortcut) => (
-              <div key={shortcut.key} className="flex items-center justify-between rounded-[14px] bg-[#f8fbff] px-3 py-2">
-                <div className="inline-flex items-center gap-2 text-[12px] text-[#5d7893]">
-                  <ClockIcon className="h-3.5 w-3.5 text-[#4DA2FF]" />
-                  {shortcut.action}
-                </div>
-                <kbd className="font-mono-ui rounded-full border border-[#d7e6f4] bg-white px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+              <div key={shortcut.key} className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2">
+                <div className="text-[12px] text-gray-600">{shortcut.action}</div>
+                <kbd className="font-mono-ui rounded bg-white px-2 py-0.5 text-[10px] font-medium text-gray-500 shadow-sm">
                   {shortcut.key}
                 </kbd>
               </div>
@@ -220,9 +209,9 @@ export default function ControlPanel() {
 
 function StatusCard({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-[14px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3">
-      <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">{label}</div>
-      <div className="font-brand mt-1 text-[14px] font-medium text-[#17324d]">{value}</div>
+    <div className="rounded-lg bg-gray-50 px-3 py-2.5">
+      <div className="text-[10px] font-medium uppercase tracking-[0.12em] text-gray-400">{label}</div>
+      <div className="mt-0.5 text-[14px] font-medium text-black">{value}</div>
     </div>
   );
 }

--- a/simulator/src/components/ControlPanel.tsx
+++ b/simulator/src/components/ControlPanel.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import { useSimulator } from '@/hooks/useSimulator';
 import { useOnChainAction } from '@/hooks/useOnChainAction';
 import { useOnChainQueue } from '@/hooks/useOnChainQueue';
+import { useSessionTracker } from '@/hooks/useSessionTracker';
+import { useCommandHistory } from '@/hooks/useCommandHistory';
 import { ChainIcon, HardwareIcon } from '@/components/icons';
 
 interface CommandButton {
@@ -55,23 +57,26 @@ const KEYBOARD_SHORTCUTS = [
 ];
 
 function formatUptime(seconds: number): string {
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  const remainingSeconds = seconds % 60;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
 
-  if (hours > 0) {
-    return `${hours}h ${minutes}m`;
-  }
-  if (minutes > 0) {
-    return `${minutes}m ${remainingSeconds}s`;
-  }
-  return `${remainingSeconds}s`;
+function formatMs(ms: number): string {
+  const m = Math.floor(ms / 60_000);
+  const s = Math.floor((ms % 60_000) / 1000);
+  return `${m}:${String(s).padStart(2, '0')}`;
 }
 
 export default function ControlPanel() {
-  const { robotState } = useSimulator();
+  const { robotState, connectedClients } = useSimulator();
   const { sendActionWithChain, pendingTxCount, isWalletConnected, isOnChainConfigured } = useOnChainAction();
   const queue = useOnChainQueue();
+  const session = useSessionTracker(isWalletConnected, robotState?.commandsExecuted ?? 0);
+  const history = useCommandHistory();
   const [showShortcuts, setShowShortcuts] = useState(false);
 
   const currentAction = robotState?.action ?? 'idle';
@@ -82,98 +87,111 @@ export default function ControlPanel() {
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
       if (event.repeat) return;
-
       const target = event.target;
       if (target instanceof HTMLElement) {
-        const tagName = target.tagName.toLowerCase();
-        if (tagName === 'input' || tagName === 'textarea' || target.isContentEditable) return;
+        const t = target.tagName.toLowerCase();
+        if (t === 'input' || t === 'textarea' || target.isContentEditable) return;
       }
-
       const key = event.code === 'Space' ? 'Space' : event.key.toUpperCase();
-      const shortcut = KEYBOARD_SHORTCUTS.find((entry) => entry.key === key);
+      const shortcut = KEYBOARD_SHORTCUTS.find((e) => e.key === key);
       if (!shortcut) return;
-
       event.preventDefault();
       sendActionWithChain(shortcut.code);
     }
-
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [sendActionWithChain]);
 
   return (
     <aside className="flex h-full min-h-[380px] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white px-4 py-4">
-      <div className="mb-4 flex items-center justify-between gap-3">
+      {/* Header */}
+      <div className="mb-3 flex items-center justify-between gap-3">
         <div>
           <div className="text-[11px] font-medium uppercase tracking-[0.12em] text-gray-400">Control</div>
-          <h2 className="mt-1 text-[16px] font-medium tracking-[-0.02em] text-black">
-            GO1 command surface
-          </h2>
+          <h2 className="mt-1 text-[16px] font-medium tracking-[-0.02em] text-black">GO1 command surface</h2>
         </div>
         <div className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1 text-[10px] font-medium text-gray-500">
           Live
         </div>
       </div>
 
-      <div className="mb-4 grid grid-cols-2 gap-2">
-        <StatusCard label="Action" value={robotState?.actionLabel ?? 'Idle'} />
-        <StatusCard label="Uptime" value={formatUptime(uptime)} />
-        <StatusCard label="Commands" value={String(commandsExecuted)} />
-        <StatusCard label="Battery" value={`${battery.toFixed(0)}%`} />
+      {/* Robot status */}
+      <div className="mb-3 grid grid-cols-2 gap-2">
+        <Stat label="Action" value={robotState?.actionLabel ?? 'Idle'} />
+        <Stat label="Uptime" value={formatUptime(uptime)} />
+        <Stat label="Commands" value={String(commandsExecuted)} />
+        <Stat label="Battery" value={`${battery.toFixed(0)}%`} />
       </div>
 
-      <div className="mb-4 rounded-xl bg-gray-50 px-3 py-3">
-        <div className="mb-2 flex items-center gap-2 text-[12px] text-gray-500">
-          <HardwareIcon className="h-4 w-4 text-[#4da2ff]" />
+      {/* Battery bar */}
+      <div className="mb-3 rounded-xl bg-gray-50 px-3 py-2.5">
+        <div className="mb-1.5 flex items-center gap-2 text-[11px] text-gray-500">
+          <HardwareIcon className="h-3.5 w-3.5 text-[#4da2ff]" />
           Battery
         </div>
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-200">
-          <div
-            className="h-full rounded-full bg-[#4da2ff]"
-            style={{ width: `${battery}%` }}
-          />
+          <div className="h-full rounded-full bg-[#4da2ff]" style={{ width: `${battery}%` }} />
         </div>
       </div>
 
+      {/* On-chain status (R2) */}
       {isOnChainConfigured && (
-        <div className="mb-4 rounded-xl bg-gray-50 px-3 py-3">
-          <div className="mb-2 flex items-center gap-2 text-[12px] text-gray-500">
-            <ChainIcon className="h-4 w-4 text-[#4da2ff]" />
-            On-chain status
-          </div>
+        <Section title="On-chain (R2)" icon={<ChainIcon className="h-3.5 w-3.5 text-[#4da2ff]" />}>
           {isWalletConnected ? (
-            <div className="grid grid-cols-2 gap-2">
-              <StatusCard label="Chain" value="Testnet" />
-              <StatusCard label="Queue" value={String(queue.queueLength)} />
-              <StatusCard label="On-chain" value={String(queue.totalActionsAdded)} />
-              <StatusCard label="Pending" value={String(pendingTxCount)} />
+            <div className="grid grid-cols-2 gap-1.5">
+              <Stat label="Chain" value="Testnet" />
+              <Stat label="Queue" value={String(queue.queueLength)} />
+              <Stat label="On-chain" value={String(queue.totalActionsAdded)} />
+              <Stat label="Pending" value={String(pendingTxCount)} />
             </div>
           ) : (
-            <div className="text-[11px] text-gray-400">
-              Connect wallet for on-chain mode
-            </div>
+            <div className="text-[11px] text-gray-400">Connect wallet for on-chain mode</div>
           )}
-        </div>
+        </Section>
       )}
 
-      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+      {/* Session (R10) */}
+      {isWalletConnected && session.isActive && (
+        <Section title="Session (R10)" badge={formatMs(session.timeRemainingMs)}>
+          <div className="grid grid-cols-2 gap-1.5">
+            <Stat label="Sequence" value={String(session.sequenceNumber)} />
+            <Stat label="Commands" value={String(session.commandsUsed)} />
+            <Stat label="Cost" value={`${session.estimatedCost} TREAT`} />
+            <Stat label="Rate" value={`${session.pricePerMinute}/min`} />
+          </div>
+          <div className="mt-1.5 font-mono-ui text-[8px] text-gray-300 break-all">
+            {session.sessionId.slice(0, 24)}...
+          </div>
+        </Section>
+      )}
+
+      {/* Multiplayer (R9) */}
+      <Section title="Multiplayer (R9)">
+        <div className="grid grid-cols-2 gap-1.5">
+          <Stat label="Clients" value={String(connectedClients)} />
+          <Stat label="Your cmds" value={String(commandsExecuted)} />
+        </div>
+      </Section>
+
+      {/* Command buttons */}
+      <div className="min-h-0 flex-1 space-y-2.5 overflow-y-auto pr-1">
         {COMMAND_GROUPS.map((group) => (
-          <section key={group.title} className="rounded-xl border border-gray-200 bg-white px-3 py-3">
-            <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.12em] text-gray-400">{group.title}</div>
-            <div className="grid grid-cols-2 gap-2">
-              {group.commands.map((command) => {
-                const active = currentAction === command.code;
+          <section key={group.title} className="rounded-xl border border-gray-200 bg-white px-3 py-2.5">
+            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-[0.12em] text-gray-400">{group.title}</div>
+            <div className="grid grid-cols-2 gap-1.5">
+              {group.commands.map((cmd) => {
+                const active = currentAction === cmd.code;
                 return (
                   <button
-                    key={command.code}
-                    onClick={() => sendActionWithChain(command.code)}
+                    key={cmd.code}
+                    onClick={() => sendActionWithChain(cmd.code)}
                     className={`rounded-lg border px-3 py-2 text-left text-[12px] font-medium transition ${
                       active
                         ? 'border-[#4da2ff] bg-[#4da2ff]/5 text-black'
                         : 'border-gray-200 bg-gray-50 text-gray-600 hover:border-gray-300 hover:bg-white'
                     }`}
                   >
-                    {command.label}
+                    {cmd.label}
                   </button>
                 );
               })}
@@ -182,21 +200,51 @@ export default function ControlPanel() {
         ))}
       </div>
 
-      <div className="mt-4 rounded-xl border border-gray-200 bg-white px-3 py-3">
+      {/* Recent tx history (R2/R4) */}
+      {history.length > 0 && (
+        <div className="mt-2.5 rounded-xl bg-gray-50 px-3 py-2.5">
+          <div className="mb-1.5 text-[10px] font-medium uppercase tracking-[0.1em] text-gray-400">
+            Recent txns (R4)
+          </div>
+          <div className="max-h-[72px] space-y-1 overflow-y-auto">
+            {history.slice(0, 5).map((h, i) => (
+              <div key={i} className="flex items-center justify-between text-[9px]">
+                <span className={h.status === 'confirmed' ? 'text-emerald-500' : 'text-red-400'}>
+                  {h.action}
+                </span>
+                {h.txDigest ? (
+                  <a
+                    href={`https://suiscan.xyz/testnet/tx/${h.txDigest}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-mono-ui text-[#4da2ff] hover:underline"
+                  >
+                    {h.txDigest.slice(0, 8)}...
+                  </a>
+                ) : (
+                  <span className="text-gray-300">failed</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Keyboard shortcuts */}
+      <div className="mt-2.5 rounded-xl border border-gray-200 bg-white px-3 py-2.5">
         <button onClick={() => setShowShortcuts((v) => !v)} className="flex w-full items-center justify-between">
           <div className="text-[12px] font-medium text-black">Keyboard</div>
           <span className="rounded-full bg-gray-100 px-2.5 py-1 text-[10px] font-medium text-gray-500">
             {showShortcuts ? 'Hide' : 'Show'}
           </span>
         </button>
-
         {showShortcuts && (
-          <div className="mt-3 space-y-1.5">
-            {KEYBOARD_SHORTCUTS.map((shortcut) => (
-              <div key={shortcut.key} className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2">
-                <div className="text-[12px] text-gray-600">{shortcut.action}</div>
+          <div className="mt-2 space-y-1">
+            {KEYBOARD_SHORTCUTS.map((s) => (
+              <div key={s.key} className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-1.5">
+                <div className="text-[11px] text-gray-600">{s.action}</div>
                 <kbd className="font-mono-ui rounded bg-white px-2 py-0.5 text-[10px] font-medium text-gray-500 shadow-sm">
-                  {shortcut.key}
+                  {s.key}
                 </kbd>
               </div>
             ))}
@@ -207,11 +255,28 @@ export default function ControlPanel() {
   );
 }
 
-function StatusCard({ label, value }: { label: string; value: string }) {
+function Stat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-lg bg-gray-50 px-3 py-2.5">
-      <div className="text-[10px] font-medium uppercase tracking-[0.12em] text-gray-400">{label}</div>
-      <div className="mt-0.5 text-[14px] font-medium text-black">{value}</div>
+    <div className="rounded-lg bg-gray-50 px-2.5 py-2">
+      <div className="text-[9px] font-medium uppercase tracking-[0.12em] text-gray-400">{label}</div>
+      <div className="mt-0.5 text-[13px] font-medium text-black">{value}</div>
+    </div>
+  );
+}
+
+function Section({ title, badge, icon, children }: { title: string; badge?: string; icon?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div className="mb-3 rounded-xl bg-gray-50 px-3 py-2.5">
+      <div className="mb-1.5 flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.1em] text-gray-400">
+          {icon}
+          {title}
+        </div>
+        {badge && (
+          <span className="font-mono-ui rounded bg-gray-200 px-1.5 py-0.5 text-[9px] text-gray-600">{badge}</span>
+        )}
+      </div>
+      {children}
     </div>
   );
 }

--- a/simulator/src/components/ControlPanel.tsx
+++ b/simulator/src/components/ControlPanel.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSimulator } from '@/hooks/useSimulator';
+import { ClockIcon, HardwareIcon, SuiDropletIcon } from '@/components/icons';
+
+interface CommandButton {
+  code: string;
+  label: string;
+}
+
+interface CommandGroup {
+  title: string;
+  commands: CommandButton[];
+}
+
+const COMMAND_GROUPS: CommandGroup[] = [
+  {
+    title: 'Posture',
+    commands: [
+      { code: 'sit', label: 'Sit' },
+      { code: 'balance', label: 'Stand' },
+      { code: 'up', label: 'Up' },
+      { code: 'rest', label: 'Rest' },
+    ],
+  },
+  {
+    title: 'Action',
+    commands: [
+      { code: 'hi', label: 'Wave' },
+      { code: 'jmp', label: 'Jump' },
+      { code: 'pu', label: 'Push-up' },
+      { code: 'str', label: 'Stretch' },
+    ],
+  },
+  {
+    title: 'Motion',
+    commands: [
+      { code: 'wkF', label: 'Forward' },
+      { code: 'bk', label: 'Back' },
+      { code: 'wkL', label: 'Left' },
+      { code: 'wkR', label: 'Right' },
+    ],
+  },
+];
+
+const KEYBOARD_SHORTCUTS = [
+  { action: 'Forward', code: 'wkF', key: 'W' },
+  { action: 'Back', code: 'bk', key: 'S' },
+  { action: 'Left', code: 'wkL', key: 'A' },
+  { action: 'Right', code: 'wkR', key: 'D' },
+  { action: 'Jump', code: 'jmp', key: 'Space' },
+];
+
+function formatUptime(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainingSeconds = seconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+  return `${remainingSeconds}s`;
+}
+
+export default function ControlPanel() {
+  const { robotState, sendAction } = useSimulator();
+  const [showShortcuts, setShowShortcuts] = useState(false);
+
+  const currentAction = robotState?.action ?? 'idle';
+  const battery = robotState?.battery ?? 100;
+  const commandsExecuted = robotState?.commandsExecuted ?? 0;
+  const uptime = robotState?.uptime ?? 0;
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.repeat) {
+        return;
+      }
+
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        const tagName = target.tagName.toLowerCase();
+        if (tagName === 'input' || tagName === 'textarea' || target.isContentEditable) {
+          return;
+        }
+      }
+
+      const key = event.code === 'Space' ? 'Space' : event.key.toUpperCase();
+      const shortcut = KEYBOARD_SHORTCUTS.find((entry) => entry.key === key);
+      if (!shortcut) {
+        return;
+      }
+
+      event.preventDefault();
+      sendAction(shortcut.code);
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [sendAction]);
+
+  return (
+    <aside className="surface-panel flex h-full min-h-[380px] flex-col overflow-hidden px-4 py-4">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <div className="lesson-eyebrow">Control</div>
+          <h2 className="font-brand mt-1 text-[16px] font-medium tracking-[-0.03em] text-[#011829]">
+            GO1 command surface
+          </h2>
+        </div>
+        <div className="inline-flex items-center gap-1.5 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+          <SuiDropletIcon className="h-3.5 w-3.5 text-[#4DA2FF]" />
+          Live
+        </div>
+      </div>
+
+      <div className="mb-4 grid grid-cols-2 gap-2">
+        <StatusCard label="Action" value={robotState?.actionLabel ?? 'Idle'} />
+        <StatusCard label="Uptime" value={formatUptime(uptime)} />
+        <StatusCard label="Commands" value={String(commandsExecuted)} />
+        <StatusCard label="Battery" value={`${battery.toFixed(0)}%`} />
+      </div>
+
+      <div className="mb-4 rounded-[16px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3">
+        <div className="mb-2 flex items-center gap-2 text-[12px] text-[#5d7893]">
+          <HardwareIcon className="h-4 w-4 text-[#4DA2FF]" />
+          Battery envelope
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-white">
+          <div
+            className="h-full rounded-full bg-[linear-gradient(90deg,#4DA2FF_0%,#1f8f6f_100%)]"
+            style={{ width: `${battery}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+        {COMMAND_GROUPS.map((group) => (
+          <section key={group.title} className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
+            <div className="mb-2 text-[11px] uppercase tracking-[0.18em] text-[#6f8ba6]">{group.title}</div>
+            <div className="grid grid-cols-2 gap-2">
+              {group.commands.map((command) => {
+                const active = currentAction === command.code;
+                return (
+                  <button
+                    key={command.code}
+                    onClick={() => sendAction(command.code)}
+                    className={`rounded-[14px] border px-3 py-2 text-left text-[12px] font-medium transition ${
+                      active
+                        ? 'border-[#c9def1] bg-[#f4f8fc] text-[#17324d]'
+                        : 'border-[#d7e6f4] bg-[#f8fbff] text-[#5d7893] hover:border-[#bfd6ea] hover:bg-white'
+                    }`}
+                  >
+                    {command.label}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <div className="mt-4 rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
+        <button onClick={() => setShowShortcuts((value) => !value)} className="flex w-full items-center justify-between">
+          <div className="text-[12px] font-medium text-[#17324d]">Keyboard</div>
+          <span className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+            {showShortcuts ? 'Hide' : 'Show'}
+          </span>
+        </button>
+
+        {showShortcuts && (
+          <div className="mt-3 space-y-2">
+            {KEYBOARD_SHORTCUTS.map((shortcut) => (
+              <div key={shortcut.key} className="flex items-center justify-between rounded-[14px] bg-[#f8fbff] px-3 py-2">
+                <div className="inline-flex items-center gap-2 text-[12px] text-[#5d7893]">
+                  <ClockIcon className="h-3.5 w-3.5 text-[#4DA2FF]" />
+                  {shortcut.action}
+                </div>
+                <kbd className="font-mono-ui rounded-full border border-[#d7e6f4] bg-white px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+                  {shortcut.key}
+                </kbd>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function StatusCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[14px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3">
+      <div className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">{label}</div>
+      <div className="font-brand mt-1 text-[14px] font-medium text-[#17324d]">{value}</div>
+    </div>
+  );
+}

--- a/simulator/src/components/ControlPanel.tsx
+++ b/simulator/src/components/ControlPanel.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { useSimulator } from '@/hooks/useSimulator';
-import { ClockIcon, HardwareIcon, SuiDropletIcon } from '@/components/icons';
+import { useOnChainAction } from '@/hooks/useOnChainAction';
+import { useOnChainQueue } from '@/hooks/useOnChainQueue';
+import { ChainIcon, ClockIcon, HardwareIcon } from '@/components/icons';
 
 interface CommandButton {
   code: string;
@@ -67,7 +69,9 @@ function formatUptime(seconds: number): string {
 }
 
 export default function ControlPanel() {
-  const { robotState, sendAction } = useSimulator();
+  const { robotState } = useSimulator();
+  const { sendActionWithChain, pendingTxCount, isWalletConnected, isOnChainConfigured } = useOnChainAction();
+  const queue = useOnChainQueue();
   const [showShortcuts, setShowShortcuts] = useState(false);
 
   const currentAction = robotState?.action ?? 'idle';
@@ -96,14 +100,14 @@ export default function ControlPanel() {
       }
 
       event.preventDefault();
-      sendAction(shortcut.code);
+      sendActionWithChain(shortcut.code);
     }
 
     window.addEventListener('keydown', handleKeyDown);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [sendAction]);
+  }, [sendActionWithChain]);
 
   return (
     <aside className="surface-panel flex h-full min-h-[380px] flex-col overflow-hidden px-4 py-4">
@@ -115,7 +119,6 @@ export default function ControlPanel() {
           </h2>
         </div>
         <div className="inline-flex items-center gap-1.5 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
-          <SuiDropletIcon className="h-3.5 w-3.5 text-[#4DA2FF]" />
           Live
         </div>
       </div>
@@ -140,6 +143,27 @@ export default function ControlPanel() {
         </div>
       </div>
 
+      {isOnChainConfigured && (
+        <div className="mb-4 rounded-[16px] border border-[#d7e6f4] bg-[#f8fbff] px-3 py-3">
+          <div className="mb-2 flex items-center gap-2 text-[12px] text-[#5d7893]">
+            <ChainIcon className="h-4 w-4 text-[#4DA2FF]" />
+            On-chain status
+          </div>
+          {isWalletConnected ? (
+            <div className="grid grid-cols-2 gap-2">
+              <StatusCard label="Chain" value="Testnet" />
+              <StatusCard label="Queue" value={String(queue.queueLength)} />
+              <StatusCard label="On-chain" value={String(queue.totalActionsAdded)} />
+              <StatusCard label="Pending" value={String(pendingTxCount)} />
+            </div>
+          ) : (
+            <div className="text-[11px] text-[#6f8ba6]">
+              Connect wallet for on-chain mode
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
         {COMMAND_GROUPS.map((group) => (
           <section key={group.title} className="rounded-[16px] border border-[#d7e6f4] bg-white px-3 py-3">
@@ -150,7 +174,7 @@ export default function ControlPanel() {
                 return (
                   <button
                     key={command.code}
-                    onClick={() => sendAction(command.code)}
+                    onClick={() => sendActionWithChain(command.code)}
                     className={`rounded-[14px] border px-3 py-2 text-left text-[12px] font-medium transition ${
                       active
                         ? 'border-[#c9def1] bg-[#f4f8fc] text-[#17324d]'

--- a/simulator/src/components/DiagramCanvas.tsx
+++ b/simulator/src/components/DiagramCanvas.tsx
@@ -513,7 +513,7 @@ export default function DiagramCanvas({ moduleId }: DiagramCanvasProps) {
   return (
     <canvas
       ref={canvasRef}
-      className="h-[200px] w-full rounded-[24px] border border-[#d7e6f4] bg-[#f8fbff]"
+      className="h-[200px] w-full rounded-xl border border-gray-200 bg-gray-50"
       style={{ imageRendering: 'auto' }}
     />
   );

--- a/simulator/src/components/DiagramCanvas.tsx
+++ b/simulator/src/components/DiagramCanvas.tsx
@@ -1,0 +1,520 @@
+'use client';
+
+import React, { useRef, useEffect } from 'react';
+
+interface DiagramCanvasProps {
+  moduleId: string;
+}
+
+// ── Color palette ─────────────────────────────────────────────
+const COLORS = {
+  blue: '#4DA2FF',
+  purple: '#3459D1',
+  cyan: '#0F8CB8',
+  yellow: '#E29A2A',
+  green: '#1F8F6F',
+  orange: '#F48A3D',
+  bg: '#F8FBFF',
+  line: '#B9D4EB',
+  text: '#16314B',
+  muted: '#6F8BA6',
+};
+
+// ── Helper drawing functions ──────────────────────────────────
+
+function sketchLine(
+  ctx: CanvasRenderingContext2D,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  color: string = COLORS.line,
+  width: number = 1.5
+) {
+  ctx.strokeStyle = color;
+  ctx.lineWidth = width;
+  ctx.setLineDash([]);
+  ctx.beginPath();
+  // Add slight wobble for hand-drawn feel
+  const mx = (x1 + x2) / 2 + (Math.random() - 0.5) * 2;
+  const my = (y1 + y2) / 2 + (Math.random() - 0.5) * 2;
+  ctx.moveTo(x1, y1);
+  ctx.quadraticCurveTo(mx, my, x2, y2);
+  ctx.stroke();
+}
+
+function sketchArrow(
+  ctx: CanvasRenderingContext2D,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  color: string = COLORS.line,
+  width: number = 1.5
+) {
+  sketchLine(ctx, x1, y1, x2, y2, color, width);
+  // Arrowhead
+  const angle = Math.atan2(y2 - y1, x2 - x1);
+  const headLen = 8;
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.moveTo(x2, y2);
+  ctx.lineTo(
+    x2 - headLen * Math.cos(angle - Math.PI / 6),
+    y2 - headLen * Math.sin(angle - Math.PI / 6)
+  );
+  ctx.lineTo(
+    x2 - headLen * Math.cos(angle + Math.PI / 6),
+    y2 - headLen * Math.sin(angle + Math.PI / 6)
+  );
+  ctx.closePath();
+  ctx.fill();
+}
+
+function sketchRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  color: string,
+  radius: number = 6
+) {
+  ctx.fillStyle = color + '20';
+  ctx.strokeStyle = color + '60';
+  ctx.lineWidth = 1.5;
+  ctx.setLineDash([]);
+  ctx.beginPath();
+  ctx.roundRect(x, y, w, h, radius);
+  ctx.fill();
+  ctx.stroke();
+}
+
+function boxWithLabel(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  label: string,
+  color: string,
+  fontSize: number = 11
+) {
+  sketchRect(ctx, x, y, w, h, color);
+  ctx.fillStyle = color;
+  ctx.font = `600 ${fontSize}px "TWK Everett", "Inter Tight", sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(label, x + w / 2, y + h / 2);
+}
+
+function dashedLine(
+  ctx: CanvasRenderingContext2D,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  color: string = COLORS.muted
+) {
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  ctx.setLineDash([4, 4]);
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.stroke();
+  ctx.setLineDash([]);
+}
+
+function labelText(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  text: string,
+  color: string = COLORS.text,
+  fontSize: number = 10,
+  align: CanvasTextAlign = 'center'
+) {
+  ctx.fillStyle = color;
+  ctx.font = `500 ${fontSize}px "Google Sans", sans-serif`;
+  ctx.textAlign = align;
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, x, y);
+}
+
+function monoText(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  text: string,
+  color: string = COLORS.cyan,
+  fontSize: number = 10
+) {
+  ctx.fillStyle = color;
+  ctx.font = `500 ${fontSize}px "IBM Plex Mono", monospace`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(text, x, y);
+}
+
+// ── Diagram drawing functions for each module ─────────────────
+
+function drawR1(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R1: Code -> serialport -> USB Driver -> Bittle -> Servos
+  const cy = h / 2;
+  const startX = 40;
+  const gap = (w - 80) / 4;
+
+  const boxes = [
+    { label: 'Your Code', color: COLORS.blue },
+    { label: 'serialport', color: COLORS.purple },
+    { label: 'USB Driver', color: COLORS.cyan },
+    { label: 'Bittle', color: COLORS.yellow },
+    { label: 'Servos', color: COLORS.green },
+  ];
+
+  boxes.forEach((box, i) => {
+    const x = startX + i * gap;
+    boxWithLabel(ctx, x - 40, cy - 18, 80, 36, box.label, box.color);
+    if (i < boxes.length - 1) {
+      sketchArrow(ctx, x + 42, cy, x + gap - 42, cy, box.color);
+    }
+  });
+
+  // Byte visualization
+  monoText(ctx, w / 2, cy + 50, 'k  s  i  t  \\n', COLORS.cyan, 12);
+  labelText(ctx, w / 2, cy + 68, 'Serial byte stream', COLORS.muted, 9);
+
+  // Title
+  labelText(ctx, w / 2, 20, 'R1: Serial Communication Flow', COLORS.text, 13);
+}
+
+function drawR2(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R2: User -> Sui Network -> ActionQueue (shared) with events
+  const cy = h / 2 - 10;
+
+  boxWithLabel(ctx, 40, cy - 18, 80, 36, 'User', COLORS.blue);
+  sketchArrow(ctx, 122, cy, 178, cy, COLORS.blue);
+  boxWithLabel(ctx, 180, cy - 18, 110, 36, 'Sui Network', COLORS.purple);
+  sketchArrow(ctx, 292, cy, 348, cy, COLORS.purple);
+  boxWithLabel(ctx, 350, cy - 18, 110, 36, 'ActionQueue', COLORS.yellow);
+
+  // Shared object annotation
+  monoText(ctx, 405, cy + 35, 'shared object', COLORS.yellow, 9);
+
+  // Events coming out
+  sketchArrow(ctx, 462, cy, 520, cy - 30, COLORS.green);
+  sketchArrow(ctx, 462, cy, 520, cy, COLORS.green);
+  sketchArrow(ctx, 462, cy, 520, cy + 30, COLORS.green);
+  labelText(ctx, 555, cy - 30, 'event: Enqueued', COLORS.green, 9, 'left');
+  labelText(ctx, 555, cy, 'event: Executed', COLORS.green, 9, 'left');
+  labelText(ctx, 555, cy + 30, 'event: Completed', COLORS.green, 9, 'left');
+
+  labelText(ctx, w / 2, 20, 'R2: Move Contract Architecture', COLORS.text, 13);
+}
+
+function drawR3(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R3: 3 Clients <-> WS Server -> Robot State -> Broadcast
+  const cy = h / 2;
+  const clientX = 60;
+  const serverX = w / 2 - 40;
+  const stateX = w - 160;
+
+  // 3 clients
+  for (let i = -1; i <= 1; i++) {
+    const y = cy + i * 45;
+    boxWithLabel(ctx, clientX - 40, y - 14, 80, 28, `Client ${i + 2}`, COLORS.blue);
+    // Bidirectional arrows
+    sketchArrow(ctx, clientX + 42, y, serverX - 42, cy, COLORS.cyan);
+  }
+
+  boxWithLabel(ctx, serverX - 40, cy - 20, 80, 40, 'WS Server', COLORS.purple);
+
+  sketchArrow(ctx, serverX + 42, cy, stateX - 2, cy, COLORS.purple);
+  boxWithLabel(ctx, stateX, cy - 18, 100, 36, 'Robot State', COLORS.yellow);
+
+  // Broadcast label
+  labelText(ctx, serverX, cy + 40, 'broadcast', COLORS.muted, 9);
+
+  labelText(ctx, w / 2, 20, 'R3: WebSocket Hub Architecture', COLORS.text, 13);
+}
+
+function drawR4(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R4: Blockchain -> Processor (poll loop) -> Serial -> Robot
+  const cy = h / 2;
+  const gap = (w - 60) / 4;
+
+  const boxes = [
+    { label: 'Blockchain', color: COLORS.purple },
+    { label: 'Processor', color: COLORS.blue },
+    { label: 'Serial', color: COLORS.cyan },
+    { label: 'Robot', color: COLORS.yellow },
+  ];
+
+  boxes.forEach((box, i) => {
+    const x = 50 + i * gap;
+    boxWithLabel(ctx, x - 45, cy - 18, 90, 36, box.label, box.color);
+    if (i < boxes.length - 1) {
+      sketchArrow(ctx, x + 47, cy, x + gap - 47, cy, box.color);
+    }
+  });
+
+  // Poll loop annotation
+  const procX = 50 + gap;
+  sketchArrow(ctx, procX, cy - 20, procX - 30, cy - 45, COLORS.muted);
+  sketchArrow(ctx, procX - 30, cy - 45, procX + 30, cy - 45, COLORS.muted);
+  sketchArrow(ctx, procX + 30, cy - 45, procX, cy - 20, COLORS.muted);
+  monoText(ctx, procX, cy - 55, 'poll loop', COLORS.muted, 9);
+
+  labelText(ctx, w / 2, 20, 'R4: Blockchain-to-Robot Pipeline', COLORS.text, 13);
+}
+
+function drawR5(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R5: Browser <-> WS Server -> Serial -> Robot (queue mode)
+  const cy = h / 2;
+
+  boxWithLabel(ctx, 30, cy - 18, 80, 36, 'Browser', COLORS.blue);
+  sketchArrow(ctx, 112, cy - 5, 168, cy - 5, COLORS.blue);
+  sketchArrow(ctx, 168, cy + 5, 112, cy + 5, COLORS.green);
+
+  boxWithLabel(ctx, 170, cy - 22, 100, 44, 'WS Server', COLORS.purple);
+
+  sketchArrow(ctx, 272, cy, 338, cy, COLORS.purple);
+  boxWithLabel(ctx, 340, cy - 18, 80, 36, 'Serial', COLORS.cyan);
+
+  sketchArrow(ctx, 422, cy, 478, cy, COLORS.cyan);
+  boxWithLabel(ctx, 480, cy - 18, 80, 36, 'Robot', COLORS.yellow);
+
+  // Queue annotation
+  monoText(ctx, 220, cy + 40, 'command queue', COLORS.muted, 9);
+  dashedLine(ctx, 170, cy + 24, 270, cy + 24, COLORS.muted);
+
+  labelText(ctx, w / 2, 20, 'R5: Live Control Architecture', COLORS.text, 13);
+}
+
+function drawR6(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R6: Remote User -> Internet (NAT) -> Cloudflare -> Tunnel -> Your PC -> Robot
+  const cy = h / 2;
+  const boxes = [
+    { label: 'Remote User', color: COLORS.blue, w: 85 },
+    { label: 'Internet', color: COLORS.muted, w: 70 },
+    { label: 'Cloudflare', color: COLORS.orange, w: 85 },
+    { label: 'Tunnel', color: COLORS.cyan, w: 65 },
+    { label: 'Your PC', color: COLORS.green, w: 70 },
+    { label: 'Robot', color: COLORS.yellow, w: 60 },
+  ];
+
+  const totalW = boxes.reduce((s, b) => s + b.w, 0);
+  const spacing = (w - 60 - totalW) / (boxes.length - 1);
+  let x = 30;
+
+  boxes.forEach((box, i) => {
+    boxWithLabel(ctx, x, cy - 16, box.w, 32, box.label, box.color, 10);
+    if (i < boxes.length - 1) {
+      const nextX = x + box.w + spacing;
+      sketchArrow(ctx, x + box.w + 2, cy, nextX - 2, cy, box.color);
+      x = nextX;
+    }
+  });
+
+  // NAT annotation
+  labelText(ctx, 155, cy - 28, 'NAT traversal', COLORS.muted, 9);
+
+  labelText(ctx, w / 2, 20, 'R6: Tunnel Architecture', COLORS.text, 13);
+}
+
+function drawR7(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R7: Client-Server timeline
+  const colClient = 120;
+  const colServer = w - 120;
+  const topY = 55;
+  const stepH = 35;
+
+  // Vertical lines
+  dashedLine(ctx, colClient, topY, colClient, h - 20, COLORS.blue);
+  dashedLine(ctx, colServer, topY, colServer, h - 20, COLORS.purple);
+
+  labelText(ctx, colClient, topY - 15, 'Client', COLORS.blue, 12);
+  labelText(ctx, colServer, topY - 15, 'Server', COLORS.purple, 12);
+
+  const steps = [
+    { from: colClient, to: colServer, label: '1. Send pubkey', color: COLORS.blue },
+    { from: colServer, to: colClient, label: '2. Challenge (nonce)', color: COLORS.purple },
+    { from: colClient, to: colServer, label: '3. Sign challenge', color: COLORS.cyan },
+    { from: colServer, to: colServer, label: '4. Verify signature', color: COLORS.yellow },
+    { from: colServer, to: colClient, label: '5. AUTH SUCCESS', color: COLORS.green },
+  ];
+
+  steps.forEach((step, i) => {
+    const y = topY + 20 + i * stepH;
+    if (step.from === step.to) {
+      // Self-loop (verify)
+      sketchRect(ctx, step.from - 60, y - 10, 120, 20, step.color, 4);
+      monoText(ctx, step.from, y, step.label, step.color, 9);
+    } else {
+      sketchArrow(ctx, step.from, y, step.to, y, step.color);
+      const midX = (step.from + step.to) / 2;
+      monoText(ctx, midX, y - 10, step.label, step.color, 9);
+    }
+  });
+
+  labelText(ctx, w / 2, 20, 'R7: Authentication Sequence', COLORS.text, 13);
+}
+
+function drawR8(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R8: Faucet -> COOKIE -> Pay -> Robot Pet queue -> Execute
+  const cy = h / 2;
+  const boxes = [
+    { label: 'Faucet', color: COLORS.cyan, w: 65 },
+    { label: 'COOKIE', color: COLORS.yellow, w: 70 },
+    { label: 'Pay', color: COLORS.orange, w: 50 },
+    { label: 'Pet Queue', color: COLORS.purple, w: 80 },
+    { label: 'Execute', color: COLORS.green, w: 70 },
+  ];
+
+  const totalW = boxes.reduce((s, b) => s + b.w, 0);
+  const spacing = (w - 60 - totalW) / (boxes.length - 1);
+  let x = 30;
+
+  boxes.forEach((box, i) => {
+    boxWithLabel(ctx, x, cy - 16, box.w, 32, box.label, box.color, 10);
+    if (i < boxes.length - 1) {
+      const nextX = x + box.w + spacing;
+      sketchArrow(ctx, x + box.w + 2, cy, nextX - 2, cy, box.color);
+      x = nextX;
+    }
+  });
+
+  // OTW annotation
+  sketchRect(ctx, w / 2 - 40, cy + 30, 80, 22, COLORS.orange, 4);
+  monoText(ctx, w / 2, cy + 41, 'OTW pattern', COLORS.orange, 9);
+  dashedLine(ctx, w / 2, cy + 16, w / 2, cy + 30, COLORS.orange);
+
+  labelText(ctx, w / 2, 20, 'R8: Pay-to-Play Token Flow', COLORS.text, 13);
+}
+
+function drawR9(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R9: 3 Users -> Fairness Queue -> WS broadcast -> 3 dApps
+  const cy = h / 2;
+  const userX = 60;
+  const queueX = w / 2 - 50;
+  const dappX = w - 80;
+
+  // 3 users on left
+  for (let i = -1; i <= 1; i++) {
+    const y = cy + i * 40;
+    boxWithLabel(ctx, userX - 35, y - 12, 70, 24, `User ${i + 2}`, COLORS.blue, 10);
+    sketchArrow(ctx, userX + 37, y, queueX - 2, cy, COLORS.blue);
+  }
+
+  boxWithLabel(ctx, queueX, cy - 20, 100, 40, 'Fairness\nQueue', COLORS.purple, 10);
+
+  // WS broadcast
+  labelText(ctx, queueX + 50, cy + 35, 'WS broadcast', COLORS.muted, 9);
+
+  // 3 dApps on right
+  for (let i = -1; i <= 1; i++) {
+    const y = cy + i * 40;
+    sketchArrow(ctx, queueX + 102, cy, dappX - 37, y, COLORS.green);
+    boxWithLabel(ctx, dappX - 35, y - 12, 70, 24, `dApp ${i + 2}`, COLORS.green, 10);
+  }
+
+  labelText(ctx, w / 2, 20, 'R9: Multiplayer Fairness Architecture', COLORS.text, 13);
+}
+
+function drawR10(ctx: CanvasRenderingContext2D, w: number, h: number) {
+  // R10: Get TREAT -> Browse -> Start Session -> Sign Commands -> Robot -> End -> Settlement
+  const cy = h / 2;
+  const boxes = [
+    { label: 'Get TREAT', color: COLORS.yellow, w: 75 },
+    { label: 'Browse', color: COLORS.blue, w: 65 },
+    { label: 'Session', color: COLORS.purple, w: 65 },
+    { label: 'Sign Cmds', color: COLORS.cyan, w: 75 },
+    { label: 'Robot', color: COLORS.green, w: 60 },
+    { label: 'End', color: COLORS.orange, w: 45 },
+    { label: 'Settle', color: COLORS.yellow, w: 60 },
+  ];
+
+  const totalW = boxes.reduce((s, b) => s + b.w, 0);
+  const spacing = (w - 50 - totalW) / (boxes.length - 1);
+  let x = 25;
+
+  boxes.forEach((box, i) => {
+    boxWithLabel(ctx, x, cy - 14, box.w, 28, box.label, box.color, 9);
+    if (i < boxes.length - 1) {
+      const nextX = x + box.w + spacing;
+      sketchArrow(ctx, x + box.w + 1, cy, nextX - 1, cy, box.color, 1);
+      x = nextX;
+    }
+  });
+
+  // Step numbers
+  x = 25;
+  boxes.forEach((box, i) => {
+    monoText(ctx, x + box.w / 2, cy - 26, `${i + 1}`, COLORS.muted, 9);
+    if (i < boxes.length - 1) {
+      x = x + box.w + spacing;
+    }
+  });
+
+  labelText(ctx, w / 2, 20, 'R10: Robot Rental Platform Flow', COLORS.text, 13);
+}
+
+// ── Diagram dispatcher ────────────────────────────────────────
+
+const DIAGRAM_MAP: Record<string, (ctx: CanvasRenderingContext2D, w: number, h: number) => void> = {
+  R1: drawR1,
+  R2: drawR2,
+  R3: drawR3,
+  R4: drawR4,
+  R5: drawR5,
+  R6: drawR6,
+  R7: drawR7,
+  R8: drawR8,
+  R9: drawR9,
+  R10: drawR10,
+};
+
+export default function DiagramCanvas({ moduleId }: DiagramCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // Set canvas size with DPR
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    ctx.scale(dpr, dpr);
+
+    // Clear
+    ctx.clearRect(0, 0, rect.width, rect.height);
+
+    // Draw background
+    ctx.fillStyle = COLORS.bg;
+    ctx.beginPath();
+    ctx.roundRect(0, 0, rect.width, rect.height, 12);
+    ctx.fill();
+
+    // Draw the appropriate diagram
+    const drawFn = DIAGRAM_MAP[moduleId.toUpperCase()];
+    if (drawFn) {
+      drawFn(ctx, rect.width, rect.height);
+    } else {
+      labelText(ctx, rect.width / 2, rect.height / 2, `Diagram for ${moduleId}`, COLORS.muted, 14);
+    }
+  }, [moduleId]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="h-[200px] w-full rounded-[24px] border border-[#d7e6f4] bg-[#f8fbff]"
+      style={{ imageRendering: 'auto' }}
+    />
+  );
+}

--- a/simulator/src/components/EnvironmentLoader.tsx
+++ b/simulator/src/components/EnvironmentLoader.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+interface EnvironmentLoaderProps {
+  onLoadFile: (file: File) => void;
+  onClear: () => void;
+  hasEnvironment: boolean;
+  loading: boolean;
+}
+
+export default function EnvironmentLoader({ onLoadFile, onClear, hasEnvironment, loading }: EnvironmentLoaderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragging(false);
+      const file = e.dataTransfer.files[0];
+      if (file && (file.name.endsWith('.glb') || file.name.endsWith('.gltf'))) {
+        onLoadFile(file);
+      }
+    },
+    [onLoadFile],
+  );
+
+  const handleFileInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) onLoadFile(file);
+      e.target.value = '';
+    },
+    [onLoadFile],
+  );
+
+  if (hasEnvironment) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] text-emerald-500">Environment loaded</span>
+        <button
+          onClick={onClear}
+          className="rounded bg-gray-100 px-2 py-0.5 text-[10px] text-gray-500 hover:bg-gray-200"
+        >
+          Clear
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+      onDragLeave={() => setDragging(false)}
+      onDrop={handleDrop}
+      onClick={() => inputRef.current?.click()}
+      className={`cursor-pointer rounded-lg border border-dashed px-3 py-2 text-center text-[10px] transition ${
+        dragging ? 'border-[#4da2ff] bg-[#4da2ff]/5 text-[#4da2ff]' : 'border-gray-300 text-gray-400 hover:border-gray-400'
+      }`}
+    >
+      {loading ? 'Loading...' : 'Drop GLB file or click to load environment'}
+      <input ref={inputRef} type="file" accept=".glb,.gltf" className="hidden" onChange={handleFileInput} />
+    </div>
+  );
+}

--- a/simulator/src/components/ModuleCard.tsx
+++ b/simulator/src/components/ModuleCard.tsx
@@ -1,17 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import {
-  ArrowRightIcon,
-  BridgeIcon,
-  ClockIcon,
-  CompassIcon,
-  HardwareIcon,
-  ShieldWaveIcon,
-  StackIcon,
-} from '@/components/icons';
+import { ArrowRightIcon, ClockIcon, HardwareIcon } from '@/components/icons';
 
-interface ModuleCardProps {
+export interface ModuleCardProps {
   order: number;
   id: string;
   title: string;
@@ -23,13 +15,6 @@ interface ModuleCardProps {
   artifact: string;
   focus: string[];
 }
-
-const CATEGORY_THEMES = {
-  Fundamentals: { icon: CompassIcon, accent: 'text-[#1d79e6]' },
-  Integration: { icon: BridgeIcon, accent: 'text-[#0f7eaa]' },
-  Security: { icon: ShieldWaveIcon, accent: 'text-[#3459d1]' },
-  'Full-Stack': { icon: StackIcon, accent: 'text-[#274965]' },
-};
 
 export default function ModuleCard({
   order,
@@ -43,62 +28,54 @@ export default function ModuleCard({
   artifact,
   focus,
 }: ModuleCardProps) {
-  const theme = CATEGORY_THEMES[category as keyof typeof CATEGORY_THEMES] ?? CATEGORY_THEMES.Fundamentals;
-  const Icon = theme.icon;
-
   return (
     <Link
       href={`/module/${id}`}
-      className="group rounded-[18px] border border-[#d7e6f4] bg-white px-4 py-4 transition hover:border-[#bfd6ea] hover:shadow-[0_10px_22px_rgba(1,24,41,0.05)]"
+      className="group rounded-xl border border-gray-200 bg-white p-4 transition hover:border-gray-300 hover:shadow-sm"
     >
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-3">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] text-[11px] font-medium text-[#17324d]">
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gray-100 text-[11px] font-medium text-gray-600">
             {order}
           </div>
           <div>
-            <div className="flex items-center gap-2">
-              <span className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">{id}</span>
-              <span className={`inline-flex items-center gap-1 ${theme.accent}`}>
-                <Icon className="h-3.5 w-3.5" />
-              </span>
-            </div>
-            <div className="font-brand mt-1 text-[16px] font-medium tracking-[-0.03em] text-[#011829]">{title}</div>
-            <div className="mt-1 text-[12px] leading-5 text-[#6f8ba6]">{subtitle}</div>
+            <div className="text-[11px] font-medium uppercase tracking-[0.1em] text-gray-400">{id}</div>
+            <div className="mt-1 text-[16px] font-medium tracking-[-0.02em] text-black">{title}</div>
+            <div className="mt-0.5 text-[12px] text-gray-500">{subtitle}</div>
           </div>
         </div>
-        <span className="shrink-0 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+        <span className="shrink-0 rounded-full bg-gray-100 px-2.5 py-1 text-[10px] font-medium text-gray-500">
           {category}
         </span>
       </div>
 
-      <p className="mt-3 text-[13px] leading-5 text-[#5d7893]">{summary}</p>
+      <p className="mt-3 text-[13px] leading-5 text-gray-500">{summary}</p>
 
-      <div className="mt-3 flex flex-wrap gap-2">
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-50 px-2.5 py-1 text-[10px] font-medium text-gray-500">
           <ClockIcon className="h-3.5 w-3.5" />
           {time}
         </span>
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
-          {hardware ? <HardwareIcon className="h-3.5 w-3.5" /> : <Icon className="h-3.5 w-3.5" />}
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-50 px-2.5 py-1 text-[10px] font-medium text-gray-500">
+          <HardwareIcon className="h-3.5 w-3.5" />
           {hardware ? 'Simulator' : 'Software'}
         </span>
-        <span className="inline-flex items-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+        <span className="rounded-full bg-gray-50 px-2.5 py-1 text-[10px] font-medium text-gray-500">
           {artifact}
         </span>
       </div>
 
       <div className="mt-3 flex flex-wrap gap-1.5">
         {focus.slice(0, 3).map((item) => (
-          <span key={item} className="rounded-full bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+          <span key={item} className="rounded bg-gray-50 px-2 py-0.5 text-[10px] text-gray-400">
             {item}
           </span>
         ))}
       </div>
 
-      <div className="mt-3 flex items-center justify-between text-[12px] font-medium text-[#17324d]">
+      <div className="mt-3 flex items-center justify-between border-t border-gray-100 pt-3 text-[12px] font-medium text-black">
         <span>Open lesson</span>
-        <ArrowRightIcon className="h-4 w-4 text-[#4DA2FF] transition group-hover:translate-x-1" />
+        <ArrowRightIcon className="h-4 w-4 text-[#4da2ff] transition group-hover:translate-x-0.5" />
       </div>
     </Link>
   );

--- a/simulator/src/components/ModuleCard.tsx
+++ b/simulator/src/components/ModuleCard.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  ArrowRightIcon,
+  BridgeIcon,
+  ClockIcon,
+  CompassIcon,
+  HardwareIcon,
+  ShieldWaveIcon,
+  StackIcon,
+} from '@/components/icons';
+
+interface ModuleCardProps {
+  order: number;
+  id: string;
+  title: string;
+  subtitle: string;
+  category: string;
+  time: string;
+  hardware: boolean;
+  summary: string;
+  artifact: string;
+  focus: string[];
+}
+
+const CATEGORY_THEMES = {
+  Fundamentals: { icon: CompassIcon, accent: 'text-[#1d79e6]' },
+  Integration: { icon: BridgeIcon, accent: 'text-[#0f7eaa]' },
+  Security: { icon: ShieldWaveIcon, accent: 'text-[#3459d1]' },
+  'Full-Stack': { icon: StackIcon, accent: 'text-[#274965]' },
+};
+
+export default function ModuleCard({
+  order,
+  id,
+  title,
+  subtitle,
+  category,
+  time,
+  hardware,
+  summary,
+  artifact,
+  focus,
+}: ModuleCardProps) {
+  const theme = CATEGORY_THEMES[category as keyof typeof CATEGORY_THEMES] ?? CATEGORY_THEMES.Fundamentals;
+  const Icon = theme.icon;
+
+  return (
+    <Link
+      href={`/module/${id}`}
+      className="group rounded-[18px] border border-[#d7e6f4] bg-white px-4 py-4 transition hover:border-[#bfd6ea] hover:shadow-[0_10px_22px_rgba(1,24,41,0.05)]"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] text-[11px] font-medium text-[#17324d]">
+            {order}
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">{id}</span>
+              <span className={`inline-flex items-center gap-1 ${theme.accent}`}>
+                <Icon className="h-3.5 w-3.5" />
+              </span>
+            </div>
+            <div className="font-brand mt-1 text-[16px] font-medium tracking-[-0.03em] text-[#011829]">{title}</div>
+            <div className="mt-1 text-[12px] leading-5 text-[#6f8ba6]">{subtitle}</div>
+          </div>
+        </div>
+        <span className="shrink-0 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+          {category}
+        </span>
+      </div>
+
+      <p className="mt-3 text-[13px] leading-5 text-[#5d7893]">{summary}</p>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+          <ClockIcon className="h-3.5 w-3.5" />
+          {time}
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+          {hardware ? <HardwareIcon className="h-3.5 w-3.5" /> : <Icon className="h-3.5 w-3.5" />}
+          {hardware ? 'Simulator' : 'Software'}
+        </span>
+        <span className="inline-flex items-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+          {artifact}
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {focus.slice(0, 3).map((item) => (
+          <span key={item} className="rounded-full bg-[#f8fbff] px-2.5 py-1 text-[10px] text-[#6f8ba6]">
+            {item}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-3 flex items-center justify-between text-[12px] font-medium text-[#17324d]">
+        <span>Open lesson</span>
+        <ArrowRightIcon className="h-4 w-4 text-[#4DA2FF] transition group-hover:translate-x-1" />
+      </div>
+    </Link>
+  );
+}

--- a/simulator/src/components/Navbar.tsx
+++ b/simulator/src/components/Navbar.tsx
@@ -4,20 +4,16 @@ import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { usePathname } from 'next/navigation';
 import { useSimulator } from '@/hooks/useSimulator';
-import {
-  CurriculumIcon,
-  PlaygroundIcon,
-} from '@/components/icons';
 
 const NAV_ITEMS = [
-  { label: 'Playground', href: '/playground', icon: PlaygroundIcon },
-  { label: 'Lessons', href: '/modules', icon: CurriculumIcon },
+  { label: 'Playground', href: '/playground' },
+  { label: 'Lessons', href: '/modules' },
 ];
 
 const NavbarWalletControls = dynamic(() => import('@/components/NavbarWalletControls'), {
   ssr: false,
   loading: () => (
-    <div className="rounded-full border border-[#d7e6f4] bg-white px-3 py-2 text-[11px] text-[#6f8ba6]">
+    <div className="rounded-full border border-white/20 px-3 py-1.5 text-[12px] text-white/50">
       Wallet
     </div>
   ),
@@ -33,64 +29,57 @@ export default function Navbar() {
 
   const statusColor =
     connectionStatus === 'connected'
-      ? 'bg-[#1f8f6f]'
+      ? 'bg-[#22c55e]'
       : connectionStatus === 'connecting'
-        ? 'bg-[#f4a34f]'
-        : 'bg-[#d15b64]';
+        ? 'bg-[#f59e0b]'
+        : 'bg-[#ef4444]';
 
   return (
-    <header className="border-b border-[#d7e6f4] bg-[rgba(255,255,255,0.86)] backdrop-blur-xl">
-      <div className="flex w-full items-center justify-between gap-4 px-3 py-2.5 sm:px-4">
-        <div className="flex min-w-0 items-center gap-3">
-          <Link href="/" className="min-w-0">
-            <div className="truncate text-[18px] font-medium tracking-[-0.045em] text-[#011829]">SuiBotics</div>
-            <div className="truncate text-[11px] text-[#6f8ba6]">R1-R10 robotics lessons</div>
-          </Link>
-        </div>
+    <header className="bg-[#1a1a1a]">
+      <div className="mx-auto flex w-full items-center justify-between gap-6 px-4 py-3 sm:px-6">
+        <Link href="/" className="flex items-center">
+          <span className="text-[16px] font-medium tracking-[-0.02em] text-white">SuiBotics</span>
+        </Link>
 
-        <nav className="hidden items-center gap-1.5 md:flex">
+        <nav className="hidden items-center gap-1 md:flex">
           {NAV_ITEMS.map((item) => {
-            const Icon = item.icon;
             const active = isActive(item.href);
-            const className = `inline-flex items-center gap-2 rounded-full border px-3 py-2 text-[12px] font-medium transition ${
-              active
-                ? 'border-[#c9def1] bg-white text-[#17324d]'
-                : 'border-transparent text-[#5d7893] hover:border-[#d7e6f4] hover:bg-white'
-            }`;
-
             return (
-              <Link key={item.label} href={item.href} className={className}>
-                <Icon className="h-4 w-4" />
+              <Link
+                key={item.label}
+                href={item.href}
+                className={`rounded-lg px-3.5 py-2 text-[14px] font-medium transition ${
+                  active ? 'text-white' : 'text-white/60 hover:text-white'
+                }`}
+              >
                 {item.label}
               </Link>
             );
           })}
         </nav>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
           <div
-            className="inline-flex h-8 w-8 items-center justify-center"
+            className="inline-flex h-6 w-6 items-center justify-center"
             title={`Simulator ${connectionStatus}`}
           >
-            <span className={`h-2.5 w-2.5 rounded-full ${statusColor}`} />
+            <span className={`h-2 w-2 rounded-full ${statusColor}`} />
           </div>
           <NavbarWalletControls />
         </div>
       </div>
 
-      <div className="flex gap-2 overflow-x-auto px-3 pb-2.5 sm:px-4 md:hidden">
+      <div className="flex gap-1 overflow-x-auto px-4 pb-3 sm:px-6 md:hidden">
         {NAV_ITEMS.map((item) => {
-          const Icon = item.icon;
           const active = isActive(item.href);
-          const className = `inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-2 text-[12px] font-medium transition ${
-            active
-              ? 'border-[#c9def1] bg-white text-[#17324d]'
-              : 'border-[#d7e6f4] bg-white/80 text-[#5d7893]'
-          }`;
-
           return (
-            <Link key={item.label} href={item.href} className={className}>
-              <Icon className="h-4 w-4" />
+            <Link
+              key={item.label}
+              href={item.href}
+              className={`shrink-0 rounded-lg px-3 py-1.5 text-[13px] font-medium transition ${
+                active ? 'bg-white/10 text-white' : 'text-white/50'
+              }`}
+            >
               {item.label}
             </Link>
           );

--- a/simulator/src/components/Navbar.tsx
+++ b/simulator/src/components/Navbar.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import Link from 'next/link';
+import dynamic from 'next/dynamic';
+import { usePathname } from 'next/navigation';
+import { useSimulator } from '@/hooks/useSimulator';
+import {
+  CurriculumIcon,
+  PlaygroundIcon,
+} from '@/components/icons';
+
+const NAV_ITEMS = [
+  { label: 'Playground', href: '/playground', icon: PlaygroundIcon },
+  { label: 'Lessons', href: '/modules', icon: CurriculumIcon },
+];
+
+const NavbarWalletControls = dynamic(() => import('@/components/NavbarWalletControls'), {
+  ssr: false,
+  loading: () => (
+    <div className="rounded-full border border-[#d7e6f4] bg-white px-3 py-2 text-[11px] text-[#6f8ba6]">
+      Wallet
+    </div>
+  ),
+});
+
+export default function Navbar() {
+  const pathname = usePathname();
+  const { connectionStatus } = useSimulator();
+
+  function isActive(href: string): boolean {
+    return pathname.startsWith(href);
+  }
+
+  const statusColor =
+    connectionStatus === 'connected'
+      ? 'bg-[#1f8f6f]'
+      : connectionStatus === 'connecting'
+        ? 'bg-[#f4a34f]'
+        : 'bg-[#d15b64]';
+
+  return (
+    <header className="border-b border-[#d7e6f4] bg-[rgba(255,255,255,0.86)] backdrop-blur-xl">
+      <div className="flex w-full items-center justify-between gap-4 px-3 py-2.5 sm:px-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <Link href="/" className="min-w-0">
+            <div className="truncate text-[18px] font-medium tracking-[-0.045em] text-[#011829]">SuiBotics</div>
+            <div className="truncate text-[11px] text-[#6f8ba6]">R1-R10 robotics lessons</div>
+          </Link>
+        </div>
+
+        <nav className="hidden items-center gap-1.5 md:flex">
+          {NAV_ITEMS.map((item) => {
+            const Icon = item.icon;
+            const active = isActive(item.href);
+            const className = `inline-flex items-center gap-2 rounded-full border px-3 py-2 text-[12px] font-medium transition ${
+              active
+                ? 'border-[#c9def1] bg-white text-[#17324d]'
+                : 'border-transparent text-[#5d7893] hover:border-[#d7e6f4] hover:bg-white'
+            }`;
+
+            return (
+              <Link key={item.label} href={item.href} className={className}>
+                <Icon className="h-4 w-4" />
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="flex items-center gap-2">
+          <div
+            className="inline-flex h-8 w-8 items-center justify-center"
+            title={`Simulator ${connectionStatus}`}
+          >
+            <span className={`h-2.5 w-2.5 rounded-full ${statusColor}`} />
+          </div>
+          <NavbarWalletControls />
+        </div>
+      </div>
+
+      <div className="flex gap-2 overflow-x-auto px-3 pb-2.5 sm:px-4 md:hidden">
+        {NAV_ITEMS.map((item) => {
+          const Icon = item.icon;
+          const active = isActive(item.href);
+          const className = `inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-2 text-[12px] font-medium transition ${
+            active
+              ? 'border-[#c9def1] bg-white text-[#17324d]'
+              : 'border-[#d7e6f4] bg-white/80 text-[#5d7893]'
+          }`;
+
+          return (
+            <Link key={item.label} href={item.href} className={className}>
+              <Icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+    </header>
+  );
+}

--- a/simulator/src/components/NavbarWalletControls.tsx
+++ b/simulator/src/components/NavbarWalletControls.tsx
@@ -21,7 +21,7 @@ export default function NavbarWalletControls() {
     <>
       <button
         onClick={() => setModalOpen(true)}
-        className="rounded-full bg-[#011829] px-5 py-2.5 text-[13px] font-medium text-white transition hover:bg-[#17324d]"
+        className="rounded-full bg-[#4da2ff] px-5 py-2.5 text-[13px] font-medium text-white transition hover:bg-[#3b8de6]"
       >
         Connect wallet
       </button>
@@ -45,13 +45,13 @@ function ConnectedControls({ address }: { address: string }) {
 
   return (
     <div className="flex items-center gap-2">
-      <div className="hidden rounded-full border border-[#d7e6f4] bg-white px-3 py-2 text-[11px] text-[#5d7893] lg:inline-flex">
+      <div className="hidden rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-[11px] font-medium text-white/70 lg:inline-flex">
         {shortenAddress(address)}
       </div>
       <button
         onClick={handleDisconnect}
         disabled={disconnecting}
-        className="rounded-full border border-[#d7e6f4] bg-white px-4 py-2 text-[12px] font-medium text-[#5d7893] transition hover:border-[#bfd6ea] hover:text-[#17324d] disabled:opacity-50"
+        className="rounded-full border border-white/20 px-4 py-1.5 text-[12px] font-medium text-white/70 transition hover:border-white/40 hover:text-white disabled:opacity-50"
       >
         {disconnecting ? 'Disconnecting...' : 'Disconnect'}
       </button>
@@ -109,23 +109,23 @@ function ConnectModal({ onClose }: { onClose: () => void }) {
       {/* Backdrop — full-page blur overlay */}
       <div
         style={{ position: 'absolute', inset: 0, zIndex: 0 }}
-        className="bg-[#011829]/50 backdrop-blur-md"
+        className="bg-black/50 backdrop-blur-md"
         onClick={onClose}
       />
 
       {/* Modal card */}
       <div
         style={{ position: 'relative', zIndex: 1 }}
-        className="mx-4 w-full max-w-[460px] rounded-[24px] border border-[#d7e6f4] bg-white shadow-[0_32px_80px_rgba(1,24,41,0.28)]"
+        className="mx-4 w-full max-w-[460px] rounded-2xl border border-gray-200 bg-white shadow-[0_32px_80px_rgba(0,0,0,0.25)]"
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-[#d7e6f4] px-6 py-5">
-          <h2 className="text-[18px] font-medium tracking-[-0.03em] text-[#011829]">
+        <div className="flex items-center justify-between border-b border-gray-200 px-6 py-5">
+          <h2 className="text-[18px] font-medium tracking-[-0.02em] text-black">
             Connect a Wallet
           </h2>
           <button
             onClick={onClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] text-[#5d7893] transition hover:border-[#bfd6ea] hover:text-[#17324d]"
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 text-gray-500 transition hover:bg-gray-200 hover:text-black"
           >
             <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <path d="M1 1l12 12M13 1 1 13" />
@@ -136,7 +136,7 @@ function ConnectModal({ onClose }: { onClose: () => void }) {
         {/* Wallet list */}
         <div className="px-4 py-4">
           {wallets.length === 0 ? (
-            <div className="py-8 text-center text-[13px] text-[#6f8ba6]">
+            <div className="py-8 text-center text-[13px] text-gray-400">
               No wallets detected. Install a Sui wallet extension to continue.
             </div>
           ) : (
@@ -148,7 +148,7 @@ function ConnectModal({ onClose }: { onClose: () => void }) {
                     key={wallet.name}
                     onClick={() => handleConnect(wallet)}
                     disabled={connecting !== null}
-                    className="flex w-full items-center gap-4 rounded-[16px] border border-transparent px-4 py-3.5 text-left transition hover:border-[#d7e6f4] hover:bg-[#f8fbff] disabled:opacity-50"
+                    className="flex w-full items-center gap-4 rounded-xl border border-transparent px-4 py-3.5 text-left transition hover:bg-gray-50 disabled:opacity-50"
                   >
                     {wallet.icon ? (
                       <img
@@ -159,15 +159,15 @@ function ConnectModal({ onClose }: { onClose: () => void }) {
                         className="h-9 w-9 rounded-[10px]"
                       />
                     ) : (
-                      <div className="flex h-9 w-9 items-center justify-center rounded-[10px] bg-[#e8f0f8] text-[14px] font-medium text-[#5d7893]">
+                      <div className="flex h-9 w-9 items-center justify-center rounded-[10px] bg-gray-100 text-[14px] font-medium text-gray-500">
                         {wallet.name.charAt(0)}
                       </div>
                     )}
-                    <span className="flex-1 text-[15px] font-medium text-[#011829]">
+                    <span className="flex-1 text-[15px] font-medium text-black">
                       {wallet.name}
                     </span>
                     {isConnecting && (
-                      <span className="text-[12px] text-[#6f8ba6]">Connecting...</span>
+                      <span className="text-[12px] text-gray-400">Connecting...</span>
                     )}
                   </button>
                 );
@@ -176,7 +176,7 @@ function ConnectModal({ onClose }: { onClose: () => void }) {
           )}
 
           {error && (
-            <div className="mt-3 rounded-[12px] border border-[#f5d0d3] bg-[#fef5f5] px-4 py-3 text-[12px] text-[#d15b64]">
+            <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-[12px] text-red-600">
               {error}
             </div>
           )}

--- a/simulator/src/components/NavbarWalletControls.tsx
+++ b/simulator/src/components/NavbarWalletControls.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { ConnectButton } from '@mysten/dapp-kit-react/ui';
-import { useWalletConnection } from '@mysten/dapp-kit-react';
+import { useState, useCallback } from 'react';
+import { useWalletConnection, useWallets, useDAppKit } from '@mysten/dapp-kit-react';
+import type { UiWallet } from '@wallet-standard/ui';
 
 function shortenAddress(address: string): string {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
@@ -9,17 +10,148 @@ function shortenAddress(address: string): string {
 
 export default function NavbarWalletControls() {
   const connection = useWalletConnection();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  if (connection.account) {
+    return <ConnectedControls address={connection.account.address} />;
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setModalOpen(true)}
+        className="rounded-full bg-[#011829] px-5 py-2.5 text-[13px] font-medium text-white transition hover:bg-[#17324d]"
+      >
+        Connect wallet
+      </button>
+      {modalOpen && <ConnectModal onClose={() => setModalOpen(false)} />}
+    </>
+  );
+}
+
+function ConnectedControls({ address }: { address: string }) {
+  const dAppKit = useDAppKit();
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  const handleDisconnect = useCallback(async () => {
+    setDisconnecting(true);
+    try {
+      await dAppKit.disconnectWallet();
+    } finally {
+      setDisconnecting(false);
+    }
+  }, [dAppKit]);
 
   return (
     <div className="flex items-center gap-2">
-      {connection.account ? (
-        <div className="hidden rounded-full border border-[#d7e6f4] bg-white px-3 py-2 text-[11px] text-[#5d7893] lg:inline-flex">
-          {shortenAddress(connection.account.address)}
+      <div className="hidden rounded-full border border-[#d7e6f4] bg-white px-3 py-2 text-[11px] text-[#5d7893] lg:inline-flex">
+        {shortenAddress(address)}
+      </div>
+      <button
+        onClick={handleDisconnect}
+        disabled={disconnecting}
+        className="rounded-full border border-[#d7e6f4] bg-white px-4 py-2 text-[12px] font-medium text-[#5d7893] transition hover:border-[#bfd6ea] hover:text-[#17324d] disabled:opacity-50"
+      >
+        {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+      </button>
+    </div>
+  );
+}
+
+function ConnectModal({ onClose }: { onClose: () => void }) {
+  const wallets = useWallets();
+  const dAppKit = useDAppKit();
+  const [connecting, setConnecting] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConnect = useCallback(
+    async (wallet: UiWallet) => {
+      setConnecting(wallet.name);
+      setError(null);
+      try {
+        await dAppKit.connectWallet({ wallet });
+        onClose();
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : 'Connection failed';
+        setError(msg);
+      } finally {
+        setConnecting(null);
+      }
+    },
+    [dAppKit, onClose],
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-[#011829]/40 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Modal */}
+      <div className="relative z-10 w-full max-w-[460px] rounded-[24px] border border-[#d7e6f4] bg-white shadow-[0_24px_64px_rgba(1,24,41,0.18)]">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-[#d7e6f4] px-6 py-5">
+          <h2 className="font-brand text-[18px] font-medium tracking-[-0.03em] text-[#011829]">
+            Connect a Wallet
+          </h2>
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-[#d7e6f4] bg-[#f8fbff] text-[#5d7893] transition hover:border-[#bfd6ea] hover:text-[#17324d]"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M1 1l12 12M13 1 1 13" />
+            </svg>
+          </button>
         </div>
-      ) : null}
-      <ConnectButton>
-        <span>Connect wallet</span>
-      </ConnectButton>
+
+        {/* Wallet list */}
+        <div className="px-4 py-4">
+          {wallets.length === 0 ? (
+            <div className="py-8 text-center text-[13px] text-[#6f8ba6]">
+              No wallets detected. Install a Sui wallet extension to continue.
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {wallets.map((wallet) => {
+                const isConnecting = connecting === wallet.name;
+                return (
+                  <button
+                    key={wallet.name}
+                    onClick={() => handleConnect(wallet)}
+                    disabled={connecting !== null}
+                    className="flex w-full items-center gap-4 rounded-[16px] border border-transparent px-4 py-3.5 text-left transition hover:border-[#d7e6f4] hover:bg-[#f8fbff] disabled:opacity-50"
+                  >
+                    {wallet.icon ? (
+                      <img
+                        src={wallet.icon}
+                        alt=""
+                        width={36}
+                        height={36}
+                        className="h-9 w-9 rounded-[10px]"
+                      />
+                    ) : (
+                      <div className="flex h-9 w-9 items-center justify-center rounded-[10px] bg-[#e8f0f8] text-[14px] font-medium text-[#5d7893]">
+                        {wallet.name.charAt(0)}
+                      </div>
+                    )}
+                    <span className="flex-1 text-[15px] font-medium text-[#011829]">
+                      {wallet.name}
+                    </span>
+                    {isConnecting && (
+                      <span className="text-[12px] text-[#6f8ba6]">Connecting...</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-3 rounded-[12px] border border-[#f5d0d3] bg-[#fef5f5] px-4 py-3 text-[12px] text-[#d15b64]">
+              {error}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/simulator/src/components/NavbarWalletControls.tsx
+++ b/simulator/src/components/NavbarWalletControls.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
+import { useWalletConnection } from '@mysten/dapp-kit-react';
+
+function shortenAddress(address: string): string {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+export default function NavbarWalletControls() {
+  const connection = useWalletConnection();
+
+  return (
+    <div className="flex items-center gap-2">
+      {connection.account ? (
+        <div className="hidden rounded-full border border-[#d7e6f4] bg-white px-3 py-2 text-[11px] text-[#5d7893] lg:inline-flex">
+          {shortenAddress(connection.account.address)}
+        </div>
+      ) : null}
+      <ConnectButton>
+        <span>Connect wallet</span>
+      </ConnectButton>
+    </div>
+  );
+}

--- a/simulator/src/components/NavbarWalletControls.tsx
+++ b/simulator/src/components/NavbarWalletControls.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useWalletConnection, useWallets, useDAppKit } from '@mysten/dapp-kit-react';
 import type { UiWallet } from '@wallet-standard/ui';
 
@@ -63,6 +64,25 @@ function ConnectModal({ onClose }: { onClose: () => void }) {
   const dAppKit = useDAppKit();
   const [connecting, setConnecting] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    // Lock body scroll while modal is open
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  // Close on Escape key
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
 
   const handleConnect = useCallback(
     async (wallet: UiWallet) => {
@@ -81,16 +101,26 @@ function ConnectModal({ onClose }: { onClose: () => void }) {
     [dAppKit, onClose],
   );
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* Backdrop */}
-      <div className="absolute inset-0 bg-[#011829]/40 backdrop-blur-sm" onClick={onClose} />
+  const modal = (
+    <div
+      style={{ position: 'fixed', inset: 0, zIndex: 99999 }}
+      className="flex items-center justify-center"
+    >
+      {/* Backdrop — full-page blur overlay */}
+      <div
+        style={{ position: 'absolute', inset: 0, zIndex: 0 }}
+        className="bg-[#011829]/50 backdrop-blur-md"
+        onClick={onClose}
+      />
 
-      {/* Modal */}
-      <div className="relative z-10 w-full max-w-[460px] rounded-[24px] border border-[#d7e6f4] bg-white shadow-[0_24px_64px_rgba(1,24,41,0.18)]">
+      {/* Modal card */}
+      <div
+        style={{ position: 'relative', zIndex: 1 }}
+        className="mx-4 w-full max-w-[460px] rounded-[24px] border border-[#d7e6f4] bg-white shadow-[0_32px_80px_rgba(1,24,41,0.28)]"
+      >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[#d7e6f4] px-6 py-5">
-          <h2 className="font-brand text-[18px] font-medium tracking-[-0.03em] text-[#011829]">
+          <h2 className="text-[18px] font-medium tracking-[-0.03em] text-[#011829]">
             Connect a Wallet
           </h2>
           <button
@@ -154,4 +184,7 @@ function ConnectModal({ onClose }: { onClose: () => void }) {
       </div>
     </div>
   );
+
+  if (!mounted) return null;
+  return createPortal(modal, document.body);
 }

--- a/simulator/src/components/PiPCameraPanel.tsx
+++ b/simulator/src/components/PiPCameraPanel.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface PiPCameraPanelProps {
+  names: string[];
+  canvasRefs: React.RefObject<(HTMLCanvasElement | null)[]>;
+}
+
+export default function PiPCameraPanel({ names, canvasRefs }: PiPCameraPanelProps) {
+  return (
+    <div className="absolute bottom-14 left-4 z-20 flex gap-1.5 rounded-xl border border-gray-200 bg-white/92 p-2 shadow-sm backdrop-blur-sm">
+      {names.map((name, i) => (
+        <div key={name} className="flex flex-col items-center gap-1">
+          <canvas
+            ref={(el) => {
+              if (canvasRefs.current) canvasRefs.current[i] = el;
+            }}
+            width={160}
+            height={120}
+            className="h-[60px] w-[80px] rounded border border-gray-200 bg-gray-900 object-cover"
+          />
+          <span className="text-[8px] font-medium uppercase tracking-[0.08em] text-gray-400">
+            {name}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/simulator/src/components/RobotViewport.tsx
+++ b/simulator/src/components/RobotViewport.tsx
@@ -442,27 +442,25 @@ export default function RobotViewport() {
   const actionLabel = robotState?.actionLabel ?? 'Idle';
 
   return (
-    <div className="surface-panel relative flex min-h-[360px] flex-col overflow-hidden sm:min-h-[440px] xl:min-h-[620px]">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(77,162,255,0.12),transparent_26%),radial-gradient(circle_at_bottom_right,rgba(192,230,255,0.22),transparent_36%),linear-gradient(180deg,#fbfdff_0%,#edf5fc_100%)]" />
-
-      <div className="relative z-10 flex flex-wrap items-center justify-between gap-3 border-b border-[#d7e6f4] px-4 py-3 sm:px-5">
+    <div className="relative flex min-h-[360px] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white sm:min-h-[440px] xl:min-h-[620px]">
+      <div className="relative z-10 flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-4 py-3 sm:px-5">
         <div className="flex items-center gap-3">
           <div>
-            <div className="lesson-eyebrow">Simulator</div>
-            <h2 className="font-brand mt-1 text-[15px] font-medium tracking-[-0.03em] text-[#011829] sm:text-[17px]">
+            <div className="text-[11px] font-medium uppercase tracking-[0.1em] text-gray-400">Simulator</div>
+            <h2 className="mt-1 text-[15px] font-medium tracking-[-0.02em] text-black sm:text-[17px]">
               Unitree GO1
             </h2>
           </div>
-          <span className="rounded-full border border-[#d7e6f4] bg-white/85 px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">
+          <span className="rounded-full bg-gray-100 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.1em] text-gray-500">
             {actionLabel}
           </span>
         </div>
 
-        <div className="flex items-center gap-2 text-[11px] text-[#6f8ba6]">
-          <span className="hidden rounded-full border border-[#d7e6f4] bg-white/85 px-3 py-1.5 md:inline-flex">
+        <div className="flex items-center gap-2 text-[11px] text-gray-400">
+          <span className="hidden rounded-full bg-gray-100 px-3 py-1.5 font-medium md:inline-flex">
             Orbit camera
           </span>
-          <span className="rounded-full border border-[#d7e6f4] bg-white/85 px-3 py-1.5">{gridVisible ? 'Grid on' : 'Grid off'}</span>
+          <span className="rounded-full bg-gray-100 px-3 py-1.5 font-medium">{gridVisible ? 'Grid on' : 'Grid off'}</span>
         </div>
       </div>
 
@@ -470,7 +468,7 @@ export default function RobotViewport() {
 
       {assetState !== 'ready' ? (
         <div className="pointer-events-none absolute inset-x-0 bottom-5 z-20 flex justify-center">
-          <div className="rounded-full border border-[#d7e6f4] bg-white/92 px-4 py-2 text-[12px] text-[#5d7893] shadow-[0_10px_20px_rgba(1,24,41,0.06)]">
+          <div className="rounded-full bg-white px-4 py-2 text-[12px] font-medium text-gray-500 shadow-md">
             {assetState === 'loading' ? 'Loading GO1 model...' : 'GO1 model could not be loaded.'}
           </div>
         </div>
@@ -479,14 +477,14 @@ export default function RobotViewport() {
       <div className="absolute bottom-4 right-4 z-20 flex gap-2">
         <button
           onClick={resetCamera}
-          className="flex h-9 w-9 items-center justify-center rounded-full border border-[#d7e6f4] bg-white/92 text-[#36526c] shadow-[0_8px_18px_rgba(1,24,41,0.06)] transition hover:border-[#bfd6ea] hover:text-[#011829]"
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 shadow-sm transition hover:text-black"
           title="Reset camera"
         >
           <CameraResetIcon className="h-[18px] w-[18px]" />
         </button>
         <button
           onClick={toggleGrid}
-          className="flex h-9 w-9 items-center justify-center rounded-full border border-[#d7e6f4] bg-white/92 text-[#36526c] shadow-[0_8px_18px_rgba(1,24,41,0.06)] transition hover:border-[#bfd6ea] hover:text-[#011829]"
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 shadow-sm transition hover:text-black"
           title="Toggle grid"
         >
           <GridIcon className="h-[18px] w-[18px]" />

--- a/simulator/src/components/RobotViewport.tsx
+++ b/simulator/src/components/RobotViewport.tsx
@@ -7,6 +7,9 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { CameraResetIcon, GridIcon } from '@/components/icons';
 import { SIMULATOR_TO_URDF, JOINT_LIMITS, GO1_DIMENSIONS, GO1_MASS } from '@/lib/unitree-go1';
+import { createRobotCameraRig, type RobotCameraRig } from '@/lib/camera/robot-cameras';
+import PiPCameraPanel from '@/components/PiPCameraPanel';
+import EnvironmentLoader from '@/components/EnvironmentLoader';
 
 function deg2rad(deg: number): number {
   return (deg * Math.PI) / 180;
@@ -246,14 +249,24 @@ export default function RobotViewport() {
   const movingRef = useRef(false);
   const actionRef = useRef('idle');
 
+  const robotCameraRef = useRef<RobotCameraRig | null>(null);
+  const cameraCanvasRefs = useRef<(HTMLCanvasElement | null)[]>([]);
+  const envMeshesRef = useRef<THREE.Object3D[]>([]);
+  const frameCountRef = useRef(0);
+
   const [gridVisible, setGridVisible] = useState(true);
   const [showDof, setShowDof] = useState(false);
+  const [showCameras, setShowCameras] = useState(false);
+  const [hasEnvironment, setHasEnvironment] = useState(false);
+  const [envLoading, setEnvLoading] = useState(false);
   const [assetState, setAssetState] = useState<'loading' | 'ready' | 'error'>('loading');
   const [displayAngles, setDisplayAngles] = useState<Record<string, number>>({});
   const showDofRef = useRef(false);
+  const showCamerasRef = useRef(false);
 
-  // Sync ref for animation loop
+  // Sync refs for animation loop
   useEffect(() => { showDofRef.current = showDof; }, [showDof]);
+  useEffect(() => { showCamerasRef.current = showCameras; }, [showCameras]);
 
   // Throttled angle display sync
   useEffect(() => {
@@ -385,6 +398,10 @@ export default function RobotViewport() {
           map.set('bodyRoll', createDOFIndicator(rig.body.node, 0x42a5f5, dofRadius * 1.5));
 
           dofMapRef.current = map;
+
+          // Create robot camera rig (5 cameras at URDF positions)
+          robotCameraRef.current = createRobotCameraRig(rig.body.node);
+
           setAssetState('ready');
         } catch {
           setAssetState('error');
@@ -495,6 +512,16 @@ export default function RobotViewport() {
 
       controls.update();
       renderer.render(scene, camera);
+
+      // Robot camera PiP (round-robin, 1 per frame)
+      frameCountRef.current++;
+      if (showCamerasRef.current && robotCameraRef.current && cameraCanvasRefs.current) {
+        const rig = robotCameraRef.current;
+        const idx = frameCountRef.current % rig.cameras.length;
+        rig.renderCamera(idx, renderer, scene);
+        const canvas = cameraCanvasRefs.current[idx];
+        if (canvas) rig.copyToCanvas(idx, renderer, canvas);
+      }
     }
 
     animate();
@@ -550,6 +577,50 @@ export default function RobotViewport() {
     }
     if (worldAxesRef.current) worldAxesRef.current.visible = next || true; // axes always visible
   }, [showDof]);
+
+  const toggleCameras = useCallback(() => {
+    setShowCameras((v) => !v);
+  }, []);
+
+  const loadEnvironment = useCallback((file: File) => {
+    if (!sceneRef.current) return;
+    setEnvLoading(true);
+    const url = URL.createObjectURL(file);
+    const loader = new GLTFLoader();
+    loader.load(
+      url,
+      (gltf) => {
+        const scene = sceneRef.current!;
+        // Clear previous environment
+        for (const m of envMeshesRef.current) scene.remove(m);
+        envMeshesRef.current = [];
+
+        gltf.scene.traverse((child) => {
+          if (child instanceof THREE.Mesh) {
+            child.receiveShadow = true;
+            child.castShadow = true;
+          }
+        });
+        scene.add(gltf.scene);
+        envMeshesRef.current.push(gltf.scene);
+        setHasEnvironment(true);
+        setEnvLoading(false);
+        URL.revokeObjectURL(url);
+      },
+      undefined,
+      () => {
+        setEnvLoading(false);
+        URL.revokeObjectURL(url);
+      },
+    );
+  }, []);
+
+  const clearEnvironment = useCallback(() => {
+    if (!sceneRef.current) return;
+    for (const m of envMeshesRef.current) sceneRef.current.remove(m);
+    envMeshesRef.current = [];
+    setHasEnvironment(false);
+  }, []);
 
   const actionLabel = robotState?.actionLabel ?? 'Idle';
   const { latencyMs, connectedClients } = useSimulator();
@@ -695,12 +766,45 @@ export default function RobotViewport() {
           <CameraResetIcon className="h-[18px] w-[18px]" />
         </button>
         <button
+          onClick={toggleCameras}
+          className={`flex h-9 items-center gap-1.5 rounded-full border px-3 text-[11px] font-medium shadow-sm transition ${
+            showCameras
+              ? 'border-blue-300 bg-blue-50 text-blue-600'
+              : 'border-gray-200 bg-white text-gray-500 hover:text-black'
+          }`}
+          title="Toggle robot cameras"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden="true">
+            <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+            <circle cx="12" cy="13" r="4" />
+          </svg>
+          Cam
+        </button>
+        <button
           onClick={toggleGrid}
           className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 shadow-sm transition hover:text-black"
           title="Toggle grid"
         >
           <GridIcon className="h-[18px] w-[18px]" />
         </button>
+      </div>
+
+      {/* PiP camera views */}
+      {showCameras && assetState === 'ready' && robotCameraRef.current && (
+        <PiPCameraPanel
+          names={robotCameraRef.current.names}
+          canvasRefs={cameraCanvasRefs}
+        />
+      )}
+
+      {/* Environment loader */}
+      <div className="absolute bottom-4 left-4 z-20 w-52">
+        <EnvironmentLoader
+          onLoadFile={loadEnvironment}
+          onClear={clearEnvironment}
+          hasEnvironment={hasEnvironment}
+          loading={envLoading}
+        />
       </div>
     </div>
   );

--- a/simulator/src/components/RobotViewport.tsx
+++ b/simulator/src/components/RobotViewport.tsx
@@ -5,7 +5,7 @@ import { useSimulator, type JointAngles } from '@/hooks/useSimulator';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
-import { CameraResetIcon, GridIcon, SuiDropletIcon } from '@/components/icons';
+import { CameraResetIcon, GridIcon } from '@/components/icons';
 
 function deg2rad(deg: number): number {
   return (deg * Math.PI) / 180;
@@ -444,13 +444,10 @@ export default function RobotViewport() {
 
       <div className="relative z-10 flex flex-wrap items-center justify-between gap-3 border-b border-[#d7e6f4] px-4 py-3 sm:px-5">
         <div className="flex items-center gap-3">
-          <div className="flex h-9 w-9 items-center justify-center rounded-[14px] border border-[#d7e6f4] bg-white text-[#4DA2FF] shadow-[0_8px_16px_rgba(1,24,41,0.05)]">
-            <SuiDropletIcon className="h-5 w-5" />
-          </div>
           <div>
-            <div className="lesson-eyebrow">Powered by Sui</div>
+            <div className="lesson-eyebrow">Simulator</div>
             <h2 className="font-brand mt-1 text-[15px] font-medium tracking-[-0.03em] text-[#011829] sm:text-[17px]">
-              Unitree GO1 simulator
+              Unitree GO1
             </h2>
           </div>
           <span className="rounded-full border border-[#d7e6f4] bg-white/85 px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">

--- a/simulator/src/components/RobotViewport.tsx
+++ b/simulator/src/components/RobotViewport.tsx
@@ -1,0 +1,497 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSimulator, type JointAngles } from '@/hooks/useSimulator';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { CameraResetIcon, GridIcon, SuiDropletIcon } from '@/components/icons';
+
+function deg2rad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+interface BoneBinding {
+  axis: THREE.Vector3;
+  node: THREE.Object3D;
+  origin: THREE.Quaternion;
+}
+
+interface BodyBinding extends BoneBinding {
+  basePosition: THREE.Vector3;
+}
+
+interface RobotRig {
+  baseRootPosition: THREE.Vector3;
+  body: BodyBinding;
+  feet: THREE.Object3D[];
+  frontLeftHip: BoneBinding;
+  frontLeftKnee: BoneBinding;
+  frontRightHip: BoneBinding;
+  frontRightKnee: BoneBinding;
+  backLeftHip: BoneBinding;
+  backLeftKnee: BoneBinding;
+  backRightHip: BoneBinding;
+  backRightKnee: BoneBinding;
+  root: THREE.Group;
+}
+
+function getNamedNode(root: THREE.Object3D, name: string): THREE.Object3D {
+  const node = root.getObjectByName(name);
+
+  if (!node) {
+    throw new Error(`Missing model node: ${name}`);
+  }
+
+  return node;
+}
+
+function bindBone(root: THREE.Object3D, name: string, axis: THREE.Vector3): BoneBinding {
+  const node = getNamedNode(root, name);
+  return {
+    axis,
+    node,
+    origin: node.quaternion.clone(),
+  };
+}
+
+function tintModel(root: THREE.Object3D) {
+  root.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) {
+      return;
+    }
+
+    child.castShadow = true;
+    child.receiveShadow = true;
+
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+
+    for (const material of materials) {
+      if (!(material instanceof THREE.MeshStandardMaterial)) {
+        continue;
+      }
+
+      material.roughness = 0.46;
+      material.metalness = 0.2;
+
+      if (child.name === 'Trunk') {
+        material.color.set('#4DA2FF');
+        material.emissive.set('#011829');
+        material.emissiveIntensity = 0.06;
+      } else {
+        material.color.offsetHSL(0, -0.03, -0.12);
+      }
+    }
+  });
+}
+
+function buildRig(model: THREE.Group): RobotRig {
+  const body = getNamedNode(model, 'BodyBone');
+
+  return {
+    baseRootPosition: model.position.clone(),
+    body: {
+      axis: new THREE.Vector3(1, 0, 0),
+      basePosition: body.position.clone(),
+      node: body,
+      origin: body.quaternion.clone(),
+    },
+    feet: [
+      getNamedNode(model, 'FootFLBone'),
+      getNamedNode(model, 'FootFRBone'),
+      getNamedNode(model, 'FootBLBone'),
+      getNamedNode(model, 'FootBRBone'),
+    ],
+    frontLeftHip: bindBone(model, 'ThighFLBone', new THREE.Vector3(0, 0, 1)),
+    frontLeftKnee: bindBone(model, 'CalfFLBone', new THREE.Vector3(0, 0, 1)),
+    frontRightHip: bindBone(model, 'ThighFRBone', new THREE.Vector3(0, 0, 1)),
+    frontRightKnee: bindBone(model, 'CalfFRBone', new THREE.Vector3(0, 0, 1)),
+    backLeftHip: bindBone(model, 'ThighBLBone', new THREE.Vector3(0, 0, 1)),
+    backLeftKnee: bindBone(model, 'CalfBLBone', new THREE.Vector3(0, 0, 1)),
+    backRightHip: bindBone(model, 'ThighBRBone', new THREE.Vector3(0, 0, 1)),
+    backRightKnee: bindBone(model, 'CalfBRBone', new THREE.Vector3(0, 0, 1)),
+    root: model,
+  };
+}
+
+function applyRotation(binding: BoneBinding, radians: number, blend: number) {
+  const target = binding.origin.clone().multiply(new THREE.Quaternion().setFromAxisAngle(binding.axis, radians));
+  binding.node.quaternion.slerp(target, blend);
+}
+
+function disposeScene(root: THREE.Object3D) {
+  root.traverse((child) => {
+    if (!(child instanceof THREE.Mesh)) {
+      return;
+    }
+
+    child.geometry.dispose();
+
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+    for (const material of materials) {
+      material.dispose();
+    }
+  });
+}
+
+export default function RobotViewport() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { robotState } = useSimulator();
+
+  const sceneRef = useRef<THREE.Scene | null>(null);
+  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const controlsRef = useRef<OrbitControls | null>(null);
+  const rigRef = useRef<RobotRig | null>(null);
+  const gridRef = useRef<THREE.GridHelper | null>(null);
+  const frameRef = useRef<number>(0);
+  const modelRootRef = useRef<THREE.Group | null>(null);
+
+  const targetJointsRef = useRef<JointAngles>({
+    headPitch: 0,
+    headYaw: 0,
+    tailWag: 0,
+    frontLeftHip: 0,
+    frontLeftKnee: 0,
+    frontRightHip: 0,
+    frontRightKnee: 0,
+    backLeftHip: 0,
+    backLeftKnee: 0,
+    backRightHip: 0,
+    backRightKnee: 0,
+  });
+  const targetBodyRef = useRef({ height: 0, pitch: 0, roll: 0 });
+  const movingRef = useRef(false);
+  const actionRef = useRef('idle');
+
+  const [gridVisible, setGridVisible] = useState(true);
+  const [assetState, setAssetState] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    const container = containerRef.current;
+    const scene = new THREE.Scene();
+    scene.background = null;
+    scene.fog = new THREE.FogExp2(0xeef6ff, 0.048);
+    sceneRef.current = scene;
+
+    const camera = new THREE.PerspectiveCamera(40, container.clientWidth / container.clientHeight, 0.1, 100);
+    camera.position.set(3.5, 1.95, 3.1);
+    camera.lookAt(0, 0.75, 0);
+    cameraRef.current = camera;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.05;
+    container.appendChild(renderer.domElement);
+    rendererRef.current = renderer;
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.target.set(0, 0.7, 0);
+    controls.minDistance = 2;
+    controls.maxDistance = 8;
+    controls.maxPolarAngle = Math.PI / 2.05;
+    controls.update();
+    controlsRef.current = controls;
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.9));
+
+    const hemisphere = new THREE.HemisphereLight(0xffffff, 0xdfe8f2, 1.05);
+    scene.add(hemisphere);
+
+    const keyLight = new THREE.DirectionalLight(0xffffff, 1.25);
+    keyLight.position.set(5, 8, 4);
+    keyLight.castShadow = true;
+    keyLight.shadow.mapSize.width = 1024;
+    keyLight.shadow.mapSize.height = 1024;
+    keyLight.shadow.camera.left = -4;
+    keyLight.shadow.camera.right = 4;
+    keyLight.shadow.camera.top = 4;
+    keyLight.shadow.camera.bottom = -4;
+    keyLight.shadow.camera.near = 0.5;
+    keyLight.shadow.camera.far = 18;
+    scene.add(keyLight);
+
+    const fillLight = new THREE.DirectionalLight(0x4da2ff, 0.38);
+    fillLight.position.set(-3, 4, -2);
+    scene.add(fillLight);
+
+    const ground = new THREE.Mesh(
+      new THREE.CircleGeometry(8, 64),
+      new THREE.MeshStandardMaterial({
+        color: 0xf6fbff,
+        metalness: 0,
+        roughness: 1,
+      }),
+    );
+    ground.receiveShadow = true;
+    ground.rotation.x = -Math.PI / 2;
+    scene.add(ground);
+
+    const grid = new THREE.GridHelper(8, 16, 0xb8d8f4, 0xe1edf8);
+    grid.position.y = 0.01;
+    scene.add(grid);
+    gridRef.current = grid;
+
+    const loader = new GLTFLoader();
+    loader.load(
+      '/robot-dog-unitree-go1/source/go1.glb',
+      (gltf) => {
+        try {
+          const model = gltf.scene;
+          tintModel(model);
+
+          model.rotation.y = Math.PI / 2;
+          model.scale.setScalar(2.55);
+
+          const bounds = new THREE.Box3().setFromObject(model);
+          model.position.y -= bounds.min.y;
+          model.position.x = 0;
+          model.position.z = 0;
+
+          scene.add(model);
+          modelRootRef.current = model;
+          rigRef.current = buildRig(model);
+          setAssetState('ready');
+        } catch {
+          setAssetState('error');
+        }
+      },
+      undefined,
+      () => {
+        setAssetState('error');
+      },
+    );
+
+    const clock = new THREE.Clock();
+    const footPosition = new THREE.Vector3();
+    const targetRootPosition = new THREE.Vector3();
+
+    function animate() {
+      frameRef.current = requestAnimationFrame(animate);
+
+      const dt = clock.getDelta();
+      const blend = Math.min(1, dt * 7);
+      const rig = rigRef.current;
+
+      if (rig) {
+        const joints = targetJointsRef.current;
+        const body = targetBodyRef.current;
+        const moving = movingRef.current;
+        const action = actionRef.current;
+        const elapsed = clock.getElapsedTime();
+
+        let frontLeftHip = deg2rad(joints.frontLeftHip);
+        let frontRightHip = deg2rad(joints.frontRightHip);
+        let backLeftHip = deg2rad(joints.backLeftHip);
+        let backRightHip = deg2rad(joints.backRightHip);
+        let frontLeftKnee = deg2rad(joints.frontLeftKnee);
+        let frontRightKnee = deg2rad(joints.frontRightKnee);
+        let backLeftKnee = deg2rad(joints.backLeftKnee);
+        let backRightKnee = deg2rad(joints.backRightKnee);
+
+        let bodyPitch = deg2rad(body.pitch);
+        let bodyRoll = deg2rad(body.roll);
+        let bodyLift = body.height * 0.18;
+
+        if (moving) {
+          const gaitSpeed = action.startsWith('tr') ? 10 : 7;
+          const gaitAmplitude = action.startsWith('tr') ? 0.38 : 0.24;
+          const kneeAmplitude = action.startsWith('tr') ? 0.28 : 0.18;
+          const phase = elapsed * gaitSpeed;
+          const pairA = Math.sin(phase);
+          const pairB = Math.sin(phase + Math.PI);
+          const steering =
+            action === 'wkL' || action === 'trL' ? 1 : action === 'wkR' || action === 'trR' ? -1 : 0;
+
+          frontLeftHip += pairA * gaitAmplitude;
+          backRightHip += pairA * gaitAmplitude;
+          frontRightHip += pairB * gaitAmplitude;
+          backLeftHip += pairB * gaitAmplitude;
+
+          frontLeftKnee += Math.max(0, -pairA) * kneeAmplitude;
+          backRightKnee += Math.max(0, -pairA) * kneeAmplitude;
+          frontRightKnee += Math.max(0, -pairB) * kneeAmplitude;
+          backLeftKnee += Math.max(0, -pairB) * kneeAmplitude;
+
+          bodyPitch += action === 'bk' ? -0.08 : 0.06;
+          bodyRoll += steering * 0.1 + Math.sin(phase * 0.5) * 0.035;
+          bodyLift += Math.abs(Math.sin(phase * 2)) * 0.035;
+        }
+
+        applyRotation(rig.frontLeftHip, frontLeftHip, blend);
+        applyRotation(rig.frontRightHip, frontRightHip, blend);
+        applyRotation(rig.backLeftHip, backLeftHip, blend);
+        applyRotation(rig.backRightHip, backRightHip, blend);
+        applyRotation(rig.frontLeftKnee, frontLeftKnee, blend);
+        applyRotation(rig.frontRightKnee, frontRightKnee, blend);
+        applyRotation(rig.backLeftKnee, backLeftKnee, blend);
+        applyRotation(rig.backRightKnee, backRightKnee, blend);
+
+        const bodyTarget = rig.body.origin
+          .clone()
+          .multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), bodyPitch))
+          .multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), bodyRoll));
+        rig.body.node.quaternion.slerp(bodyTarget, blend);
+
+        const bodyPosition = rig.body.basePosition.clone();
+        bodyPosition.y += bodyLift;
+        rig.body.node.position.lerp(bodyPosition, blend);
+
+        rig.root.updateMatrixWorld(true);
+
+        let minFootY = Number.POSITIVE_INFINITY;
+        for (const foot of rig.feet) {
+          foot.getWorldPosition(footPosition);
+          if (footPosition.y < minFootY) {
+            minFootY = footPosition.y;
+          }
+        }
+
+        const groundOffset = minFootY < 0 ? -minFootY + 0.004 : 0;
+        targetRootPosition.copy(rig.baseRootPosition);
+        targetRootPosition.y += groundOffset;
+        rig.root.position.lerp(targetRootPosition, blend);
+      }
+
+      controls.update();
+      renderer.render(scene, camera);
+    }
+
+    animate();
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        if (width <= 0 || height <= 0) {
+          continue;
+        }
+
+        camera.aspect = width / height;
+        camera.updateProjectionMatrix();
+        renderer.setSize(width, height);
+      }
+    });
+
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(frameRef.current);
+      controls.dispose();
+      renderer.dispose();
+
+      if (modelRootRef.current) {
+        disposeScene(modelRootRef.current);
+      }
+
+      if (container.contains(renderer.domElement)) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!robotState) {
+      return;
+    }
+
+    targetJointsRef.current = { ...robotState.joints };
+    targetBodyRef.current = {
+      height: robotState.bodyHeight,
+      pitch: robotState.bodyPitch,
+      roll: robotState.bodyRoll,
+    };
+    movingRef.current = robotState.moving;
+    actionRef.current = robotState.action;
+  }, [robotState]);
+
+  const resetCamera = useCallback(() => {
+    if (!cameraRef.current || !controlsRef.current) {
+      return;
+    }
+
+    cameraRef.current.position.set(3.5, 1.95, 3.1);
+    controlsRef.current.target.set(0, 0.7, 0);
+    controlsRef.current.update();
+  }, []);
+
+  const toggleGrid = useCallback(() => {
+    if (!gridRef.current) {
+      return;
+    }
+
+    const next = !gridRef.current.visible;
+    gridRef.current.visible = next;
+    setGridVisible(next);
+  }, []);
+
+  const actionLabel = robotState?.actionLabel ?? 'Idle';
+
+  return (
+    <div className="surface-panel relative flex min-h-[360px] flex-col overflow-hidden sm:min-h-[440px] xl:min-h-[620px]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(77,162,255,0.12),transparent_26%),radial-gradient(circle_at_bottom_right,rgba(192,230,255,0.22),transparent_36%),linear-gradient(180deg,#fbfdff_0%,#edf5fc_100%)]" />
+
+      <div className="relative z-10 flex flex-wrap items-center justify-between gap-3 border-b border-[#d7e6f4] px-4 py-3 sm:px-5">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-[14px] border border-[#d7e6f4] bg-white text-[#4DA2FF] shadow-[0_8px_16px_rgba(1,24,41,0.05)]">
+            <SuiDropletIcon className="h-5 w-5" />
+          </div>
+          <div>
+            <div className="lesson-eyebrow">Powered by Sui</div>
+            <h2 className="font-brand mt-1 text-[15px] font-medium tracking-[-0.03em] text-[#011829] sm:text-[17px]">
+              Unitree GO1 simulator
+            </h2>
+          </div>
+          <span className="rounded-full border border-[#d7e6f4] bg-white/85 px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-[#6f8ba6]">
+            {actionLabel}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 text-[11px] text-[#6f8ba6]">
+          <span className="hidden rounded-full border border-[#d7e6f4] bg-white/85 px-3 py-1.5 md:inline-flex">
+            Orbit camera
+          </span>
+          <span className="rounded-full border border-[#d7e6f4] bg-white/85 px-3 py-1.5">{gridVisible ? 'Grid on' : 'Grid off'}</span>
+        </div>
+      </div>
+
+      <div ref={containerRef} className="relative z-10 flex-1" />
+
+      {assetState !== 'ready' ? (
+        <div className="pointer-events-none absolute inset-x-0 bottom-5 z-20 flex justify-center">
+          <div className="rounded-full border border-[#d7e6f4] bg-white/92 px-4 py-2 text-[12px] text-[#5d7893] shadow-[0_10px_20px_rgba(1,24,41,0.06)]">
+            {assetState === 'loading' ? 'Loading GO1 model...' : 'GO1 model could not be loaded.'}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="absolute bottom-4 right-4 z-20 flex gap-2">
+        <button
+          onClick={resetCamera}
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-[#d7e6f4] bg-white/92 text-[#36526c] shadow-[0_8px_18px_rgba(1,24,41,0.06)] transition hover:border-[#bfd6ea] hover:text-[#011829]"
+          title="Reset camera"
+        >
+          <CameraResetIcon className="h-[18px] w-[18px]" />
+        </button>
+        <button
+          onClick={toggleGrid}
+          className="flex h-9 w-9 items-center justify-center rounded-full border border-[#d7e6f4] bg-white/92 text-[#36526c] shadow-[0_8px_18px_rgba(1,24,41,0.06)] transition hover:border-[#bfd6ea] hover:text-[#011829]"
+          title="Toggle grid"
+        >
+          <GridIcon className="h-[18px] w-[18px]" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/simulator/src/components/RobotViewport.tsx
+++ b/simulator/src/components/RobotViewport.tsx
@@ -350,6 +350,7 @@ export default function RobotViewport() {
 
         rig.root.updateMatrixWorld(true);
 
+        // Find the lowest point across all feet
         let minFootY = Number.POSITIVE_INFINITY;
         for (const foot of rig.feet) {
           foot.getWorldPosition(footPosition);
@@ -358,10 +359,12 @@ export default function RobotViewport() {
           }
         }
 
-        const groundOffset = minFootY < 0 ? -minFootY + 0.004 : 0;
-        targetRootPosition.copy(rig.baseRootPosition);
-        targetRootPosition.y += groundOffset;
-        rig.root.position.lerp(targetRootPosition, blend);
+        // Lift the entire model so no geometry goes below y=0
+        if (minFootY < 0.004) {
+          const correction = -minFootY + 0.004;
+          rig.root.position.y += correction;
+          rig.root.updateMatrixWorld(true);
+        }
       }
 
       controls.update();

--- a/simulator/src/components/RobotViewport.tsx
+++ b/simulator/src/components/RobotViewport.tsx
@@ -552,6 +552,9 @@ export default function RobotViewport() {
   }, [showDof]);
 
   const actionLabel = robotState?.actionLabel ?? 'Idle';
+  const { latencyMs, connectedClients } = useSimulator();
+
+  const latencyColor = latencyMs === null ? 'bg-gray-300' : latencyMs < 100 ? 'bg-emerald-400' : latencyMs < 300 ? 'bg-yellow-400' : 'bg-red-400';
 
   return (
     <div className="relative flex min-h-[360px] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white sm:min-h-[440px] xl:min-h-[620px]">
@@ -570,6 +573,15 @@ export default function RobotViewport() {
         </div>
 
         <div className="flex items-center gap-2 text-[11px] text-gray-400">
+          {/* Latency indicator (R5) */}
+          <span className="hidden items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1.5 font-mono-ui font-medium sm:inline-flex">
+            <span className={`h-1.5 w-1.5 rounded-full ${latencyColor}`} />
+            {latencyMs !== null ? `${latencyMs}ms` : '—'}
+          </span>
+          {/* Client count (R9) */}
+          <span className="hidden rounded-full bg-gray-100 px-3 py-1.5 font-medium md:inline-flex">
+            {connectedClients} client{connectedClients !== 1 ? 's' : ''}
+          </span>
           <span className="hidden rounded-full bg-gray-100 px-3 py-1.5 font-medium md:inline-flex">
             Orbit camera
           </span>

--- a/simulator/src/components/RobotViewport.tsx
+++ b/simulator/src/components/RobotViewport.tsx
@@ -11,6 +11,12 @@ function deg2rad(deg: number): number {
   return (deg * Math.PI) / 180;
 }
 
+function rad2deg(rad: number): number {
+  return (rad * 180) / Math.PI;
+}
+
+// ── Types ────────────────────────────────────────────────────
+
 interface BoneBinding {
   axis: THREE.Vector3;
   node: THREE.Object3D;
@@ -36,44 +42,36 @@ interface RobotRig {
   root: THREE.Group;
 }
 
+interface DOFIndicator {
+  group: THREE.Group;
+  arc: THREE.Line;
+  arcPositions: Float32Array;
+  radius: number;
+}
+
+// ── Model helpers ────────────────────────────────────────────
+
 function getNamedNode(root: THREE.Object3D, name: string): THREE.Object3D {
   const node = root.getObjectByName(name);
-
-  if (!node) {
-    throw new Error(`Missing model node: ${name}`);
-  }
-
+  if (!node) throw new Error(`Missing model node: ${name}`);
   return node;
 }
 
 function bindBone(root: THREE.Object3D, name: string, axis: THREE.Vector3): BoneBinding {
   const node = getNamedNode(root, name);
-  return {
-    axis,
-    node,
-    origin: node.quaternion.clone(),
-  };
+  return { axis, node, origin: node.quaternion.clone() };
 }
 
 function tintModel(root: THREE.Object3D) {
   root.traverse((child) => {
-    if (!(child instanceof THREE.Mesh)) {
-      return;
-    }
-
+    if (!(child instanceof THREE.Mesh)) return;
     child.castShadow = true;
     child.receiveShadow = true;
-
     const materials = Array.isArray(child.material) ? child.material : [child.material];
-
     for (const material of materials) {
-      if (!(material instanceof THREE.MeshStandardMaterial)) {
-        continue;
-      }
-
+      if (!(material instanceof THREE.MeshStandardMaterial)) continue;
       material.roughness = 0.46;
       material.metalness = 0.2;
-
       if (child.name === 'Trunk') {
         material.color.set('#4DA2FF');
         material.emissive.set('#011829');
@@ -87,21 +85,10 @@ function tintModel(root: THREE.Object3D) {
 
 function buildRig(model: THREE.Group): RobotRig {
   const body = getNamedNode(model, 'BodyBone');
-
   return {
     baseRootPosition: model.position.clone(),
-    body: {
-      axis: new THREE.Vector3(1, 0, 0),
-      basePosition: body.position.clone(),
-      node: body,
-      origin: body.quaternion.clone(),
-    },
-    feet: [
-      getNamedNode(model, 'FootFLBone'),
-      getNamedNode(model, 'FootFRBone'),
-      getNamedNode(model, 'FootBLBone'),
-      getNamedNode(model, 'FootBRBone'),
-    ],
+    body: { axis: new THREE.Vector3(1, 0, 0), basePosition: body.position.clone(), node: body, origin: body.quaternion.clone() },
+    feet: [getNamedNode(model, 'FootFLBone'), getNamedNode(model, 'FootFRBone'), getNamedNode(model, 'FootBLBone'), getNamedNode(model, 'FootBRBone')],
     frontLeftHip: bindBone(model, 'ThighFLBone', new THREE.Vector3(0, 0, 1)),
     frontLeftKnee: bindBone(model, 'CalfFLBone', new THREE.Vector3(0, 0, 1)),
     frontRightHip: bindBone(model, 'ThighFRBone', new THREE.Vector3(0, 0, 1)),
@@ -121,18 +108,124 @@ function applyRotation(binding: BoneBinding, radians: number, blend: number) {
 
 function disposeScene(root: THREE.Object3D) {
   root.traverse((child) => {
-    if (!(child instanceof THREE.Mesh)) {
-      return;
-    }
-
+    if (!(child instanceof THREE.Mesh)) return;
     child.geometry.dispose();
-
     const materials = Array.isArray(child.material) ? child.material : [child.material];
-    for (const material of materials) {
-      material.dispose();
-    }
+    for (const material of materials) material.dispose();
   });
 }
+
+// ── DOF visualization helpers ────────────────────────────────
+
+const ARC_SEGMENTS = 32;
+
+function createDOFIndicator(bone: THREE.Object3D, color: number, radius: number): DOFIndicator {
+  const group = new THREE.Group();
+  group.visible = false;
+
+  // Torus ring showing rotation plane (Z-axis = XY plane)
+  const ringGeom = new THREE.TorusGeometry(radius, radius * 0.06, 8, 32);
+  const ringMat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.25, depthTest: false });
+  const ring = new THREE.Mesh(ringGeom, ringMat);
+  group.add(ring);
+
+  // Axis arrow
+  const arrow = new THREE.ArrowHelper(
+    new THREE.Vector3(0, 0, 1), new THREE.Vector3(), radius * 1.4, color, radius * 0.25, radius * 0.12,
+  );
+  (arrow.line as THREE.Line).material = new THREE.LineBasicMaterial({ color, depthTest: false });
+  ((arrow.cone as THREE.Mesh).material as THREE.MeshBasicMaterial).depthTest = false;
+  group.add(arrow);
+
+  // Angle arc (pre-allocated buffer)
+  const arcPositions = new Float32Array((ARC_SEGMENTS + 1) * 3);
+  const arcGeom = new THREE.BufferGeometry();
+  arcGeom.setAttribute('position', new THREE.BufferAttribute(arcPositions, 3));
+  arcGeom.setDrawRange(0, 0);
+  const arcMat = new THREE.LineBasicMaterial({ color, linewidth: 2, depthTest: false });
+  const arc = new THREE.Line(arcGeom, arcMat);
+  group.add(arc);
+
+  bone.add(group);
+  return { group, arc, arcPositions, radius };
+}
+
+function updateDOFArc(indicator: DOFIndicator, angle: number) {
+  const { arcPositions, radius, arc } = indicator;
+  const absAngle = Math.abs(angle);
+  if (absAngle < 0.001) {
+    arc.geometry.setDrawRange(0, 0);
+    return;
+  }
+  const segments = Math.min(ARC_SEGMENTS, Math.max(2, Math.ceil(absAngle / (Math.PI / 16))));
+  const dir = angle > 0 ? 1 : -1;
+  for (let i = 0; i <= segments; i++) {
+    const t = (i / segments) * absAngle * dir;
+    const idx = i * 3;
+    arcPositions[idx] = Math.cos(t) * radius * 1.15;
+    arcPositions[idx + 1] = Math.sin(t) * radius * 1.15;
+    arcPositions[idx + 2] = 0;
+  }
+  (arc.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+  arc.geometry.setDrawRange(0, segments + 1);
+}
+
+function createWorldAxes(): THREE.Group {
+  const group = new THREE.Group();
+  const len = 0.7;
+  const headLen = 0.1;
+  const headW = 0.04;
+  const yOff = new THREE.Vector3(0, 0.005, 0);
+
+  group.add(new THREE.ArrowHelper(new THREE.Vector3(1, 0, 0), yOff, len, 0xef4444, headLen, headW));
+  group.add(new THREE.ArrowHelper(new THREE.Vector3(0, 1, 0), yOff, len, 0x22c55e, headLen, headW));
+  group.add(new THREE.ArrowHelper(new THREE.Vector3(0, 0, 1), yOff, len, 0x4da2ff, headLen, headW));
+
+  // Labels
+  for (const [text, color, pos] of [
+    ['X', '#ef4444', new THREE.Vector3(len + 0.08, 0.005, 0)],
+    ['Y', '#22c55e', new THREE.Vector3(0, len + 0.08, 0)],
+    ['Z', '#4da2ff', new THREE.Vector3(0, 0.005, len + 0.08)],
+  ] as [string, string, THREE.Vector3][]) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+    const ctx = canvas.getContext('2d')!;
+    ctx.fillStyle = color;
+    ctx.font = 'bold 48px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(text, 32, 32);
+    const texture = new THREE.CanvasTexture(canvas);
+    const mat = new THREE.SpriteMaterial({ map: texture, depthTest: false });
+    const sprite = new THREE.Sprite(mat);
+    sprite.position.copy(pos);
+    sprite.scale.setScalar(0.12);
+    group.add(sprite);
+  }
+
+  return group;
+}
+
+// ── Joint name mapping ───────────────────────────────────────
+
+const JOINT_LABELS: Record<string, string> = {
+  frontLeftHip: 'FL Hip',
+  frontLeftKnee: 'FL Knee',
+  frontRightHip: 'FR Hip',
+  frontRightKnee: 'FR Knee',
+  backLeftHip: 'BL Hip',
+  backLeftKnee: 'BL Knee',
+  backRightHip: 'BR Hip',
+  backRightKnee: 'BR Knee',
+};
+
+const JOINT_COLORS: Record<string, number> = {
+  frontLeftHip: 0xffa726, frontRightHip: 0xffa726, backLeftHip: 0xffa726, backRightHip: 0xffa726,
+  frontLeftKnee: 0x26c6da, frontRightKnee: 0x26c6da, backLeftKnee: 0x26c6da, backRightKnee: 0x26c6da,
+};
+
+// ── Component ────────────────────────────────────────────────
 
 export default function RobotViewport() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -146,36 +239,46 @@ export default function RobotViewport() {
   const gridRef = useRef<THREE.GridHelper | null>(null);
   const frameRef = useRef<number>(0);
   const modelRootRef = useRef<THREE.Group | null>(null);
+  const dofMapRef = useRef<Map<string, DOFIndicator>>(new Map());
+  const worldAxesRef = useRef<THREE.Group | null>(null);
+  const displayAnglesRef = useRef<Record<string, number>>({});
 
   const targetJointsRef = useRef<JointAngles>({
-    headPitch: 0,
-    headYaw: 0,
-    tailWag: 0,
-    frontLeftHip: 0,
-    frontLeftKnee: 0,
-    frontRightHip: 0,
-    frontRightKnee: 0,
-    backLeftHip: 0,
-    backLeftKnee: 0,
-    backRightHip: 0,
-    backRightKnee: 0,
+    headPitch: 0, headYaw: 0, tailWag: 0,
+    frontLeftHip: 0, frontLeftKnee: 0, frontRightHip: 0, frontRightKnee: 0,
+    backLeftHip: 0, backLeftKnee: 0, backRightHip: 0, backRightKnee: 0,
   });
   const targetBodyRef = useRef({ height: 0, pitch: 0, roll: 0 });
   const movingRef = useRef(false);
   const actionRef = useRef('idle');
 
   const [gridVisible, setGridVisible] = useState(true);
+  const [showDof, setShowDof] = useState(false);
   const [assetState, setAssetState] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [displayAngles, setDisplayAngles] = useState<Record<string, number>>({});
+  const showDofRef = useRef(false);
+
+  // Sync ref for animation loop
+  useEffect(() => { showDofRef.current = showDof; }, [showDof]);
+
+  // Throttled angle display sync
+  useEffect(() => {
+    if (!showDof) return;
+    const id = setInterval(() => {
+      setDisplayAngles({ ...displayAnglesRef.current });
+    }, 100);
+    return () => clearInterval(id);
+  }, [showDof]);
+
+  // ── Main scene setup ─────────────────────────────────────
 
   useEffect(() => {
-    if (!containerRef.current) {
-      return;
-    }
-
+    if (!containerRef.current) return;
     const container = containerRef.current;
+
     const scene = new THREE.Scene();
     scene.background = null;
-    scene.fog = new THREE.FogExp2(0xeef6ff, 0.048);
+    scene.fog = new THREE.FogExp2(0xf5f5f5, 0.035);
     sceneRef.current = scene;
 
     const camera = new THREE.PerspectiveCamera(40, container.clientWidth / container.clientHeight, 0.1, 100);
@@ -204,16 +307,13 @@ export default function RobotViewport() {
     controls.update();
     controlsRef.current = controls;
 
+    // Lighting
     scene.add(new THREE.AmbientLight(0xffffff, 0.9));
-
-    const hemisphere = new THREE.HemisphereLight(0xffffff, 0xdfe8f2, 1.05);
-    scene.add(hemisphere);
-
+    scene.add(new THREE.HemisphereLight(0xffffff, 0xdfe8f2, 1.05));
     const keyLight = new THREE.DirectionalLight(0xffffff, 1.25);
     keyLight.position.set(5, 8, 4);
     keyLight.castShadow = true;
-    keyLight.shadow.mapSize.width = 1024;
-    keyLight.shadow.mapSize.height = 1024;
+    keyLight.shadow.mapSize.set(1024, 1024);
     keyLight.shadow.camera.left = -4;
     keyLight.shadow.camera.right = 4;
     keyLight.shadow.camera.top = 4;
@@ -221,28 +321,39 @@ export default function RobotViewport() {
     keyLight.shadow.camera.near = 0.5;
     keyLight.shadow.camera.far = 18;
     scene.add(keyLight);
+    scene.add(new THREE.DirectionalLight(0x4da2ff, 0.38).translateX(-3).translateY(4).translateZ(-2));
 
-    const fillLight = new THREE.DirectionalLight(0x4da2ff, 0.38);
-    fillLight.position.set(-3, 4, -2);
-    scene.add(fillLight);
-
+    // Ground
     const ground = new THREE.Mesh(
       new THREE.CircleGeometry(8, 64),
-      new THREE.MeshStandardMaterial({
-        color: 0xf6fbff,
-        metalness: 0,
-        roughness: 1,
-      }),
+      new THREE.MeshStandardMaterial({ color: 0xf0f0f0, metalness: 0, roughness: 1 }),
     );
     ground.receiveShadow = true;
     ground.rotation.x = -Math.PI / 2;
     scene.add(ground);
 
-    const grid = new THREE.GridHelper(8, 16, 0xb8d8f4, 0xe1edf8);
+    // Grid with colored axis lines
+    const grid = new THREE.GridHelper(8, 16, 0xcccccc, 0xe0e0e0);
     grid.position.y = 0.01;
     scene.add(grid);
     gridRef.current = grid;
 
+    const xAxisLine = new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(-4, 0.012, 0), new THREE.Vector3(4, 0.012, 0)]),
+      new THREE.LineBasicMaterial({ color: 0xef4444, linewidth: 2 }),
+    );
+    const zAxisLine = new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0, 0.012, -4), new THREE.Vector3(0, 0.012, 4)]),
+      new THREE.LineBasicMaterial({ color: 0x4da2ff, linewidth: 2 }),
+    );
+    scene.add(xAxisLine, zAxisLine);
+
+    // World coordinate axes
+    const worldAxes = createWorldAxes();
+    scene.add(worldAxes);
+    worldAxesRef.current = worldAxes;
+
+    // Load model
     const loader = new GLTFLoader();
     loader.load(
       '/robot-dog-unitree-go1/source/go1.glb',
@@ -250,36 +361,51 @@ export default function RobotViewport() {
         try {
           const model = gltf.scene;
           tintModel(model);
-
           model.rotation.y = Math.PI / 2;
           model.scale.setScalar(2.55);
-
           const bounds = new THREE.Box3().setFromObject(model);
           model.position.y -= bounds.min.y;
           model.position.x = 0;
           model.position.z = 0;
-
           scene.add(model);
           modelRootRef.current = model;
-          rigRef.current = buildRig(model);
+
+          const rig = buildRig(model);
+          rigRef.current = rig;
+
+          // Create DOF indicators for each joint
+          const dofRadius = 0.025; // in bone-local space
+          const map = new Map<string, DOFIndicator>();
+          const jointBindings: [string, BoneBinding][] = [
+            ['frontLeftHip', rig.frontLeftHip], ['frontLeftKnee', rig.frontLeftKnee],
+            ['frontRightHip', rig.frontRightHip], ['frontRightKnee', rig.frontRightKnee],
+            ['backLeftHip', rig.backLeftHip], ['backLeftKnee', rig.backLeftKnee],
+            ['backRightHip', rig.backRightHip], ['backRightKnee', rig.backRightKnee],
+          ];
+          for (const [name, binding] of jointBindings) {
+            const color = JOINT_COLORS[name] ?? 0xffa726;
+            map.set(name, createDOFIndicator(binding.node, color, dofRadius));
+          }
+          // Body pitch + roll indicators
+          map.set('bodyPitch', createDOFIndicator(rig.body.node, 0xef5350, dofRadius * 1.5));
+          map.set('bodyRoll', createDOFIndicator(rig.body.node, 0x42a5f5, dofRadius * 1.5));
+
+          dofMapRef.current = map;
           setAssetState('ready');
         } catch {
           setAssetState('error');
         }
       },
       undefined,
-      () => {
-        setAssetState('error');
-      },
+      () => setAssetState('error'),
     );
 
+    // Animation
     const clock = new THREE.Clock();
     const footPosition = new THREE.Vector3();
-    const targetRootPosition = new THREE.Vector3();
 
     function animate() {
       frameRef.current = requestAnimationFrame(animate);
-
       const dt = clock.getDelta();
       const blend = Math.min(1, dt * 7);
       const rig = rigRef.current;
@@ -299,7 +425,6 @@ export default function RobotViewport() {
         let frontRightKnee = deg2rad(joints.frontRightKnee);
         let backLeftKnee = deg2rad(joints.backLeftKnee);
         let backRightKnee = deg2rad(joints.backRightKnee);
-
         let bodyPitch = deg2rad(body.pitch);
         let bodyRoll = deg2rad(body.roll);
         let bodyLift = body.height * 0.18;
@@ -311,23 +436,27 @@ export default function RobotViewport() {
           const phase = elapsed * gaitSpeed;
           const pairA = Math.sin(phase);
           const pairB = Math.sin(phase + Math.PI);
-          const steering =
-            action === 'wkL' || action === 'trL' ? 1 : action === 'wkR' || action === 'trR' ? -1 : 0;
+          const steering = action === 'wkL' || action === 'trL' ? 1 : action === 'wkR' || action === 'trR' ? -1 : 0;
 
           frontLeftHip += pairA * gaitAmplitude;
           backRightHip += pairA * gaitAmplitude;
           frontRightHip += pairB * gaitAmplitude;
           backLeftHip += pairB * gaitAmplitude;
-
           frontLeftKnee += Math.max(0, -pairA) * kneeAmplitude;
           backRightKnee += Math.max(0, -pairA) * kneeAmplitude;
           frontRightKnee += Math.max(0, -pairB) * kneeAmplitude;
           backLeftKnee += Math.max(0, -pairB) * kneeAmplitude;
-
           bodyPitch += action === 'bk' ? -0.08 : 0.06;
           bodyRoll += steering * 0.1 + Math.sin(phase * 0.5) * 0.035;
           bodyLift += Math.abs(Math.sin(phase * 2)) * 0.035;
         }
+
+        // Store display angles
+        displayAnglesRef.current = {
+          frontLeftHip, frontLeftKnee, frontRightHip, frontRightKnee,
+          backLeftHip, backLeftKnee, backRightHip, backRightKnee,
+          bodyPitch, bodyRoll,
+        };
 
         applyRotation(rig.frontLeftHip, frontLeftHip, blend);
         applyRotation(rig.frontRightHip, frontRightHip, blend);
@@ -338,8 +467,7 @@ export default function RobotViewport() {
         applyRotation(rig.backLeftKnee, backLeftKnee, blend);
         applyRotation(rig.backRightKnee, backRightKnee, blend);
 
-        const bodyTarget = rig.body.origin
-          .clone()
+        const bodyTarget = rig.body.origin.clone()
           .multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), bodyPitch))
           .multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), bodyRoll));
         rig.body.node.quaternion.slerp(bodyTarget, blend);
@@ -350,20 +478,24 @@ export default function RobotViewport() {
 
         rig.root.updateMatrixWorld(true);
 
-        // Find the lowest point across all feet
+        // Ground clamping
         let minFootY = Number.POSITIVE_INFINITY;
         for (const foot of rig.feet) {
           foot.getWorldPosition(footPosition);
-          if (footPosition.y < minFootY) {
-            minFootY = footPosition.y;
-          }
+          if (footPosition.y < minFootY) minFootY = footPosition.y;
+        }
+        if (minFootY < 0.004) {
+          rig.root.position.y += -minFootY + 0.004;
+          rig.root.updateMatrixWorld(true);
         }
 
-        // Lift the entire model so no geometry goes below y=0
-        if (minFootY < 0.004) {
-          const correction = -minFootY + 0.004;
-          rig.root.position.y += correction;
-          rig.root.updateMatrixWorld(true);
+        // Update DOF arcs
+        if (showDofRef.current) {
+          const angles: Record<string, number> = displayAnglesRef.current;
+          for (const [name, indicator] of dofMapRef.current) {
+            const angle = angles[name] ?? 0;
+            updateDOFArc(indicator, angle);
+          }
         }
       }
 
@@ -376,16 +508,12 @@ export default function RobotViewport() {
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const { width, height } = entry.contentRect;
-        if (width <= 0 || height <= 0) {
-          continue;
-        }
-
+        if (width <= 0 || height <= 0) continue;
         camera.aspect = width / height;
         camera.updateProjectionMatrix();
         renderer.setSize(width, height);
       }
     });
-
     observer.observe(container);
 
     return () => {
@@ -393,56 +521,47 @@ export default function RobotViewport() {
       cancelAnimationFrame(frameRef.current);
       controls.dispose();
       renderer.dispose();
-
-      if (modelRootRef.current) {
-        disposeScene(modelRootRef.current);
-      }
-
-      if (container.contains(renderer.domElement)) {
-        container.removeChild(renderer.domElement);
-      }
+      if (modelRootRef.current) disposeScene(modelRootRef.current);
+      if (container.contains(renderer.domElement)) container.removeChild(renderer.domElement);
     };
   }, []);
 
   useEffect(() => {
-    if (!robotState) {
-      return;
-    }
-
+    if (!robotState) return;
     targetJointsRef.current = { ...robotState.joints };
-    targetBodyRef.current = {
-      height: robotState.bodyHeight,
-      pitch: robotState.bodyPitch,
-      roll: robotState.bodyRoll,
-    };
+    targetBodyRef.current = { height: robotState.bodyHeight, pitch: robotState.bodyPitch, roll: robotState.bodyRoll };
     movingRef.current = robotState.moving;
     actionRef.current = robotState.action;
   }, [robotState]);
 
   const resetCamera = useCallback(() => {
-    if (!cameraRef.current || !controlsRef.current) {
-      return;
-    }
-
+    if (!cameraRef.current || !controlsRef.current) return;
     cameraRef.current.position.set(3.5, 1.95, 3.1);
     controlsRef.current.target.set(0, 0.7, 0);
     controlsRef.current.update();
   }, []);
 
   const toggleGrid = useCallback(() => {
-    if (!gridRef.current) {
-      return;
-    }
-
+    if (!gridRef.current) return;
     const next = !gridRef.current.visible;
     gridRef.current.visible = next;
     setGridVisible(next);
   }, []);
 
+  const toggleDof = useCallback(() => {
+    const next = !showDof;
+    setShowDof(next);
+    for (const indicator of dofMapRef.current.values()) {
+      indicator.group.visible = next;
+    }
+    if (worldAxesRef.current) worldAxesRef.current.visible = next || true; // axes always visible
+  }, [showDof]);
+
   const actionLabel = robotState?.actionLabel ?? 'Idle';
 
   return (
     <div className="relative flex min-h-[360px] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white sm:min-h-[440px] xl:min-h-[620px]">
+      {/* Header bar */}
       <div className="relative z-10 flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-4 py-3 sm:px-5">
         <div className="flex items-center gap-3">
           <div>
@@ -460,21 +579,77 @@ export default function RobotViewport() {
           <span className="hidden rounded-full bg-gray-100 px-3 py-1.5 font-medium md:inline-flex">
             Orbit camera
           </span>
-          <span className="rounded-full bg-gray-100 px-3 py-1.5 font-medium">{gridVisible ? 'Grid on' : 'Grid off'}</span>
+          <span className="rounded-full bg-gray-100 px-3 py-1.5 font-medium">
+            {gridVisible ? 'Grid on' : 'Grid off'}
+          </span>
+          {showDof && (
+            <span className="rounded-full bg-orange-100 px-3 py-1.5 font-medium text-orange-600">
+              DOF
+            </span>
+          )}
         </div>
       </div>
 
+      {/* 3D Canvas */}
       <div ref={containerRef} className="relative z-10 flex-1" />
 
-      {assetState !== 'ready' ? (
+      {/* Joint angles panel */}
+      {showDof && assetState === 'ready' && (
+        <div className="absolute left-4 top-[72px] z-20 w-44 rounded-xl border border-gray-200 bg-white/92 px-3 py-3 shadow-sm backdrop-blur-sm">
+          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.12em] text-gray-400">
+            Joint angles
+          </div>
+          {Object.entries(JOINT_LABELS).map(([key, label]) => (
+            <div key={key} className="flex items-center justify-between py-[3px]">
+              <span className="text-[10px] text-gray-500">{label}</span>
+              <span className="font-mono-ui text-[10px] text-gray-700">
+                {rad2deg(displayAngles[key] ?? 0).toFixed(1)}°
+              </span>
+            </div>
+          ))}
+          <div className="mt-1.5 border-t border-gray-100 pt-1.5">
+            <div className="flex items-center justify-between py-[3px]">
+              <span className="text-[10px] text-red-400">Pitch</span>
+              <span className="font-mono-ui text-[10px] text-gray-700">
+                {rad2deg(displayAngles.bodyPitch ?? 0).toFixed(1)}°
+              </span>
+            </div>
+            <div className="flex items-center justify-between py-[3px]">
+              <span className="text-[10px] text-blue-400">Roll</span>
+              <span className="font-mono-ui text-[10px] text-gray-700">
+                {rad2deg(displayAngles.bodyRoll ?? 0).toFixed(1)}°
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {assetState !== 'ready' && (
         <div className="pointer-events-none absolute inset-x-0 bottom-5 z-20 flex justify-center">
           <div className="rounded-full bg-white px-4 py-2 text-[12px] font-medium text-gray-500 shadow-md">
             {assetState === 'loading' ? 'Loading GO1 model...' : 'GO1 model could not be loaded.'}
           </div>
         </div>
-      ) : null}
+      )}
 
+      {/* Toolbar */}
       <div className="absolute bottom-4 right-4 z-20 flex gap-2">
+        <button
+          onClick={toggleDof}
+          className={`flex h-9 items-center gap-1.5 rounded-full border px-3 text-[11px] font-medium shadow-sm transition ${
+            showDof
+              ? 'border-orange-300 bg-orange-50 text-orange-600'
+              : 'border-gray-200 bg-white text-gray-500 hover:text-black'
+          }`}
+          title="Toggle DOF visualization"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden="true">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
+          </svg>
+          DOF
+        </button>
         <button
           onClick={resetCamera}
           className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 shadow-sm transition hover:text-black"

--- a/simulator/src/components/RobotViewport.tsx
+++ b/simulator/src/components/RobotViewport.tsx
@@ -6,6 +6,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { CameraResetIcon, GridIcon } from '@/components/icons';
+import { SIMULATOR_TO_URDF, JOINT_LIMITS, GO1_DIMENSIONS, GO1_MASS } from '@/lib/unitree-go1';
 
 function deg2rad(deg: number): number {
   return (deg * Math.PI) / 180;
@@ -209,16 +210,9 @@ function createWorldAxes(): THREE.Group {
 
 // ── Joint name mapping ───────────────────────────────────────
 
-const JOINT_LABELS: Record<string, string> = {
-  frontLeftHip: 'FL Hip',
-  frontLeftKnee: 'FL Knee',
-  frontRightHip: 'FR Hip',
-  frontRightKnee: 'FR Knee',
-  backLeftHip: 'BL Hip',
-  backLeftKnee: 'BL Knee',
-  backRightHip: 'BR Hip',
-  backRightKnee: 'BR Knee',
-};
+const JOINT_LABELS: Record<string, string> = Object.fromEntries(
+  Object.entries(SIMULATOR_TO_URDF).map(([sim, urdf]) => [sim, urdf.replace('_joint', '')]),
+);
 
 const JOINT_COLORS: Record<string, number> = {
   frontLeftHip: 0xffa726, frontRightHip: 0xffa726, backLeftHip: 0xffa726, backRightHip: 0xffa726,
@@ -593,32 +587,63 @@ export default function RobotViewport() {
       {/* 3D Canvas */}
       <div ref={containerRef} className="relative z-10 flex-1" />
 
-      {/* Joint angles panel */}
+      {/* Joint angles panel — Unitree ROS SDK naming */}
       {showDof && assetState === 'ready' && (
-        <div className="absolute left-4 top-[72px] z-20 w-44 rounded-xl border border-gray-200 bg-white/92 px-3 py-3 shadow-sm backdrop-blur-sm">
-          <div className="mb-2 text-[10px] font-medium uppercase tracking-[0.12em] text-gray-400">
-            Joint angles
+        <div className="absolute left-4 top-[72px] z-20 w-52 rounded-xl border border-gray-200 bg-white/95 px-3 py-3 shadow-sm backdrop-blur-sm">
+          <div className="mb-1 text-[9px] font-medium uppercase tracking-[0.12em] text-gray-400">
+            Unitree GO1 — Joint State
           </div>
-          {Object.entries(JOINT_LABELS).map(([key, label]) => (
-            <div key={key} className="flex items-center justify-between py-[3px]">
-              <span className="text-[10px] text-gray-500">{label}</span>
-              <span className="font-mono-ui text-[10px] text-gray-700">
-                {rad2deg(displayAngles[key] ?? 0).toFixed(1)}°
-              </span>
-            </div>
-          ))}
+          <div className="mb-2 text-[8px] text-gray-300">unitree_ros / go1_description</div>
+
+          {Object.entries(JOINT_LABELS).map(([key, label]) => {
+            const angle = displayAngles[key] ?? 0;
+            const isThigh = label.includes('thigh');
+            const limits = isThigh ? JOINT_LIMITS.thigh : JOINT_LIMITS.calf;
+            const pct = Math.abs(angle - limits.lower) / (limits.upper - limits.lower) * 100;
+            return (
+              <div key={key} className="py-[2px]">
+                <div className="flex items-center justify-between">
+                  <span className="font-mono-ui text-[9px] text-gray-500">{label}</span>
+                  <span className="font-mono-ui text-[9px] text-gray-700">
+                    {rad2deg(angle).toFixed(1)}°
+                  </span>
+                </div>
+                <div className="mt-0.5 h-[3px] w-full overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    className="h-full rounded-full bg-orange-400/60"
+                    style={{ width: `${Math.min(100, Math.max(0, pct))}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+
           <div className="mt-1.5 border-t border-gray-100 pt-1.5">
-            <div className="flex items-center justify-between py-[3px]">
-              <span className="text-[10px] text-red-400">Pitch</span>
-              <span className="font-mono-ui text-[10px] text-gray-700">
+            <div className="flex items-center justify-between py-[2px]">
+              <span className="font-mono-ui text-[9px] text-red-400">body_pitch</span>
+              <span className="font-mono-ui text-[9px] text-gray-700">
                 {rad2deg(displayAngles.bodyPitch ?? 0).toFixed(1)}°
               </span>
             </div>
-            <div className="flex items-center justify-between py-[3px]">
-              <span className="text-[10px] text-blue-400">Roll</span>
-              <span className="font-mono-ui text-[10px] text-gray-700">
+            <div className="flex items-center justify-between py-[2px]">
+              <span className="font-mono-ui text-[9px] text-blue-400">body_roll</span>
+              <span className="font-mono-ui text-[9px] text-gray-700">
                 {rad2deg(displayAngles.bodyRoll ?? 0).toFixed(1)}°
               </span>
+            </div>
+          </div>
+
+          <div className="mt-2 border-t border-gray-100 pt-2">
+            <div className="text-[8px] font-medium uppercase tracking-[0.1em] text-gray-300">Kinematics</div>
+            <div className="mt-1 grid grid-cols-2 gap-x-3 gap-y-0.5 text-[8px]">
+              <span className="text-gray-400">Thigh</span>
+              <span className="font-mono-ui text-gray-500">{GO1_DIMENSIONS.thighLength}m</span>
+              <span className="text-gray-400">Calf</span>
+              <span className="font-mono-ui text-gray-500">{GO1_DIMENSIONS.calfLength}m</span>
+              <span className="text-gray-400">Mass</span>
+              <span className="font-mono-ui text-gray-500">{GO1_MASS.totalApprox}kg</span>
+              <span className="text-gray-400">DOF</span>
+              <span className="font-mono-ui text-gray-500">12 (3/leg)</span>
             </div>
           </div>
         </div>

--- a/simulator/src/components/SuiWalletProvider.tsx
+++ b/simulator/src/components/SuiWalletProvider.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { DAppKitProvider } from '@mysten/dapp-kit-react';
+import { getSuiDAppKit } from '@/lib/sui-dapp-kit';
+
+export default function SuiWalletProvider({ children }: { children: ReactNode }) {
+  if (typeof window === 'undefined') {
+    return <>{children}</>;
+  }
+
+  return <DAppKitProvider dAppKit={getSuiDAppKit()}>{children}</DAppKitProvider>;
+}

--- a/simulator/src/components/SuiWalletProvider.tsx
+++ b/simulator/src/components/SuiWalletProvider.tsx
@@ -1,13 +1,19 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { DAppKitProvider } from '@mysten/dapp-kit-react';
 import { getSuiDAppKit } from '@/lib/sui-dapp-kit';
 
 export default function SuiWalletProvider({ children }: { children: ReactNode }) {
-  if (typeof window === 'undefined') {
+  const [dAppKit, setDAppKit] = useState<ReturnType<typeof getSuiDAppKit> | null>(null);
+
+  useEffect(() => {
+    setDAppKit(getSuiDAppKit());
+  }, []);
+
+  if (!dAppKit) {
     return <>{children}</>;
   }
 
-  return <DAppKitProvider dAppKit={getSuiDAppKit()}>{children}</DAppKitProvider>;
+  return <DAppKitProvider dAppKit={dAppKit}>{children}</DAppKitProvider>;
 }

--- a/simulator/src/components/Terminal.tsx
+++ b/simulator/src/components/Terminal.tsx
@@ -6,12 +6,12 @@ import { useOnChainAction } from '@/hooks/useOnChainAction';
 import { TerminalIcon } from '@/components/icons';
 
 const TYPE_COLORS: Record<TerminalEntry['type'], string> = {
-  info: 'text-[#4b6781]',
-  cmd: 'text-[#1d79e6]',
-  ok: 'text-[#1f8f6f]',
-  error: 'text-[#d15b64]',
-  event: 'text-[#3459d1]',
-  system: 'text-[#7a5df1]',
+  info: 'text-gray-500',
+  cmd: 'text-[#4da2ff]',
+  ok: 'text-emerald-600',
+  error: 'text-red-500',
+  event: 'text-blue-600',
+  system: 'text-violet-500',
 };
 
 export default function Terminal() {
@@ -23,18 +23,14 @@ export default function Terminal() {
   const [historyIndex, setHistoryIndex] = useState(-1);
 
   useEffect(() => {
-    if (!scrollRef.current) {
-      return;
-    }
+    if (!scrollRef.current) return;
     scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [terminalLogs]);
 
   const handleSubmit = useCallback(
     (value: string) => {
       const trimmed = value.trim();
-      if (!trimmed) {
-        return;
-      }
+      if (!trimmed) return;
 
       setHistory((previous) => {
         const next = [...previous, trimmed];
@@ -67,9 +63,7 @@ export default function Terminal() {
 
       if (event.key === 'ArrowUp') {
         event.preventDefault();
-        if (history.length === 0) {
-          return;
-        }
+        if (history.length === 0) return;
         const nextIndex = historyIndex === -1 ? history.length - 1 : Math.max(0, historyIndex - 1);
         setHistoryIndex(nextIndex);
         setInput(history[nextIndex]);
@@ -78,9 +72,7 @@ export default function Terminal() {
 
       if (event.key === 'ArrowDown') {
         event.preventDefault();
-        if (historyIndex === -1) {
-          return;
-        }
+        if (historyIndex === -1) return;
         const nextIndex = historyIndex + 1;
         if (nextIndex >= history.length) {
           setHistoryIndex(-1);
@@ -96,20 +88,20 @@ export default function Terminal() {
 
   return (
     <section className="px-4 pb-4 pt-3 sm:px-6">
-      <div className="surface-panel overflow-hidden px-0 py-0">
-        <div className="flex items-center justify-between border-b border-[#d7e6f4] px-4 py-3">
+      <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white">
+        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
           <div className="flex items-center gap-3">
-            <div className="flex h-8 w-8 items-center justify-center rounded-[12px] border border-[#d7e6f4] bg-[#f8fbff] text-[#17324d]">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100 text-gray-600">
               <TerminalIcon className="h-4 w-4" />
             </div>
             <div>
-              <div className="lesson-eyebrow">Terminal</div>
-              <div className="font-brand mt-0.5 text-[14px] font-medium text-[#17324d]">Robot console</div>
+              <div className="text-[11px] font-medium uppercase tracking-[0.1em] text-gray-400">Terminal</div>
+              <div className="mt-0.5 text-[14px] font-medium text-black">Robot console</div>
             </div>
           </div>
           <button
             onClick={clearTerminalLogs}
-            className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-1.5 text-[10px] text-[#6f8ba6] transition hover:border-[#bfd6ea]"
+            className="rounded-full bg-gray-100 px-3 py-1.5 text-[10px] font-medium text-gray-500 transition hover:bg-gray-200"
           >
             Clear
           </button>
@@ -117,21 +109,21 @@ export default function Terminal() {
 
         <div
           ref={scrollRef}
-          className="h-[120px] overflow-y-auto bg-[linear-gradient(180deg,#fbfdff_0%,#f4f8fc_100%)] px-4 py-3 font-mono-ui text-[11px] leading-5 sm:h-[140px]"
+          className="h-[120px] overflow-y-auto bg-gray-50 px-4 py-3 font-mono-ui text-[11px] leading-5 sm:h-[140px]"
         >
-          {terminalLogs.length === 0 && <div className="text-[#8ca5bc]">Type `help` for the simulator command vocabulary.</div>}
+          {terminalLogs.length === 0 && <div className="text-gray-400">Type `help` for the simulator command vocabulary.</div>}
 
           {terminalLogs.map((entry, index) => (
             <div key={`${entry.time}-${index}`} className="grid grid-cols-[4rem_minmax(0,1fr)] gap-3">
-              <span className="text-[#9ab1c6]">{entry.time}</span>
+              <span className="text-gray-300">{entry.time}</span>
               <span className={TYPE_COLORS[entry.type]}>{entry.message}</span>
             </div>
           ))}
         </div>
 
-        <div className="border-t border-[#d7e6f4] bg-white px-4 py-3">
-          <div className="flex items-center gap-3 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-4 py-2.5">
-            <span className="font-mono-ui text-[12px] font-medium text-[#1d79e6]">&gt;</span>
+        <div className="border-t border-gray-200 bg-white px-4 py-3">
+          <div className="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5">
+            <span className="font-mono-ui text-[12px] font-medium text-[#4da2ff]">&gt;</span>
             <input
               data-terminal-input
               type="text"
@@ -142,7 +134,7 @@ export default function Terminal() {
               }}
               onKeyDown={handleKeyDown}
               placeholder="Enter a command or action"
-              className="font-mono-ui flex-1 bg-transparent text-[12px] text-[#17324d] outline-none placeholder:text-[#8ca5bc]"
+              className="font-mono-ui flex-1 bg-transparent text-[12px] text-black outline-none placeholder:text-gray-400"
               autoComplete="off"
               spellCheck={false}
             />

--- a/simulator/src/components/Terminal.tsx
+++ b/simulator/src/components/Terminal.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSimulator, type TerminalEntry } from '@/hooks/useSimulator';
+import { useOnChainAction } from '@/hooks/useOnChainAction';
 import { TerminalIcon } from '@/components/icons';
 
 const TYPE_COLORS: Record<TerminalEntry['type'], string> = {
@@ -14,7 +15,8 @@ const TYPE_COLORS: Record<TerminalEntry['type'], string> = {
 };
 
 export default function Terminal() {
-  const { terminalLogs, sendCommand, sendAction, addTerminalLog, clearTerminalLogs } = useSimulator();
+  const { terminalLogs, sendCommand, addTerminalLog, clearTerminalLogs } = useSimulator();
+  const { sendActionWithChain } = useOnChainAction();
   const scrollRef = useRef<HTMLDivElement>(null);
   const [input, setInput] = useState('');
   const [history, setHistory] = useState<string[]>([]);
@@ -48,12 +50,12 @@ export default function Terminal() {
         addTerminalLog('system', 'Commands: k<action>, clear, help');
         addTerminalLog('system', 'Actions: sit, balance, up, rest, hi, wkF, bk, trF, jmp, pu, pd, str, bf, wkL, wkR');
       } else {
-        sendAction(trimmed);
+        sendActionWithChain(trimmed);
       }
 
       setInput('');
     },
-    [addTerminalLog, clearTerminalLogs, sendAction, sendCommand],
+    [addTerminalLog, clearTerminalLogs, sendActionWithChain, sendCommand],
   );
 
   const handleKeyDown = useCallback(

--- a/simulator/src/components/Terminal.tsx
+++ b/simulator/src/components/Terminal.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSimulator, type TerminalEntry } from '@/hooks/useSimulator';
+import { TerminalIcon } from '@/components/icons';
+
+const TYPE_COLORS: Record<TerminalEntry['type'], string> = {
+  info: 'text-[#4b6781]',
+  cmd: 'text-[#1d79e6]',
+  ok: 'text-[#1f8f6f]',
+  error: 'text-[#d15b64]',
+  event: 'text-[#3459d1]',
+  system: 'text-[#7a5df1]',
+};
+
+export default function Terminal() {
+  const { terminalLogs, sendCommand, sendAction, addTerminalLog, clearTerminalLogs } = useSimulator();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [input, setInput] = useState('');
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+
+  useEffect(() => {
+    if (!scrollRef.current) {
+      return;
+    }
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [terminalLogs]);
+
+  const handleSubmit = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      setHistory((previous) => {
+        const next = [...previous, trimmed];
+        return next.length > 100 ? next.slice(-100) : next;
+      });
+      setHistoryIndex(-1);
+
+      if (trimmed.startsWith('k')) {
+        sendCommand(trimmed);
+      } else if (trimmed === 'clear') {
+        clearTerminalLogs();
+      } else if (trimmed === 'help') {
+        addTerminalLog('system', 'Commands: k<action>, clear, help');
+        addTerminalLog('system', 'Actions: sit, balance, up, rest, hi, wkF, bk, trF, jmp, pu, pd, str, bf, wkL, wkR');
+      } else {
+        sendAction(trimmed);
+      }
+
+      setInput('');
+    },
+    [addTerminalLog, clearTerminalLogs, sendAction, sendCommand],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        handleSubmit(input);
+        return;
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        if (history.length === 0) {
+          return;
+        }
+        const nextIndex = historyIndex === -1 ? history.length - 1 : Math.max(0, historyIndex - 1);
+        setHistoryIndex(nextIndex);
+        setInput(history[nextIndex]);
+        return;
+      }
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        if (historyIndex === -1) {
+          return;
+        }
+        const nextIndex = historyIndex + 1;
+        if (nextIndex >= history.length) {
+          setHistoryIndex(-1);
+          setInput('');
+          return;
+        }
+        setHistoryIndex(nextIndex);
+        setInput(history[nextIndex]);
+      }
+    },
+    [handleSubmit, history, historyIndex, input],
+  );
+
+  return (
+    <section className="px-4 pb-4 pt-3 sm:px-6">
+      <div className="surface-panel overflow-hidden px-0 py-0">
+        <div className="flex items-center justify-between border-b border-[#d7e6f4] px-4 py-3">
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 items-center justify-center rounded-[12px] border border-[#d7e6f4] bg-[#f8fbff] text-[#17324d]">
+              <TerminalIcon className="h-4 w-4" />
+            </div>
+            <div>
+              <div className="lesson-eyebrow">Terminal</div>
+              <div className="font-brand mt-0.5 text-[14px] font-medium text-[#17324d]">Robot console</div>
+            </div>
+          </div>
+          <button
+            onClick={clearTerminalLogs}
+            className="rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-3 py-1.5 text-[10px] text-[#6f8ba6] transition hover:border-[#bfd6ea]"
+          >
+            Clear
+          </button>
+        </div>
+
+        <div
+          ref={scrollRef}
+          className="h-[120px] overflow-y-auto bg-[linear-gradient(180deg,#fbfdff_0%,#f4f8fc_100%)] px-4 py-3 font-mono-ui text-[11px] leading-5 sm:h-[140px]"
+        >
+          {terminalLogs.length === 0 && <div className="text-[#8ca5bc]">Type `help` for the simulator command vocabulary.</div>}
+
+          {terminalLogs.map((entry, index) => (
+            <div key={`${entry.time}-${index}`} className="grid grid-cols-[4rem_minmax(0,1fr)] gap-3">
+              <span className="text-[#9ab1c6]">{entry.time}</span>
+              <span className={TYPE_COLORS[entry.type]}>{entry.message}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="border-t border-[#d7e6f4] bg-white px-4 py-3">
+          <div className="flex items-center gap-3 rounded-full border border-[#d7e6f4] bg-[#f8fbff] px-4 py-2.5">
+            <span className="font-mono-ui text-[12px] font-medium text-[#1d79e6]">&gt;</span>
+            <input
+              data-terminal-input
+              type="text"
+              value={input}
+              onChange={(event) => {
+                setInput(event.target.value);
+                setHistoryIndex(-1);
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder="Enter a command or action"
+              className="font-mono-ui flex-1 bg-transparent text-[12px] text-[#17324d] outline-none placeholder:text-[#8ca5bc]"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/simulator/src/components/Toast.tsx
+++ b/simulator/src/components/Toast.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export interface ToastItem {
+  id: number;
+  type: 'success' | 'error';
+  message: string;
+}
+
+let toastId = 0;
+let globalAddToast: ((item: Omit<ToastItem, 'id'>) => void) | null = null;
+
+export function showToast(type: ToastItem['type'], message: string) {
+  globalAddToast?.({ type, message });
+}
+
+const DURATION = 4000;
+
+export function ToastContainer() {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const addToast = useCallback((item: Omit<ToastItem, 'id'>) => {
+    const id = ++toastId;
+    setToasts((prev) => [...prev, { ...item, id }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, DURATION);
+  }, []);
+
+  useEffect(() => {
+    globalAddToast = addToast;
+    return () => {
+      globalAddToast = null;
+    };
+  }, [addToast]);
+
+  if (!mounted || toasts.length === 0) return null;
+
+  return createPortal(
+    <div
+      style={{ position: 'fixed', bottom: 24, right: 24, zIndex: 99998 }}
+      className="flex flex-col items-end gap-2"
+    >
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={`animate-slide-in flex items-center gap-2.5 rounded-[14px] border px-4 py-3 text-[13px] font-medium shadow-[0_8px_24px_rgba(1,24,41,0.12)] ${
+            toast.type === 'success'
+              ? 'border-[#b8e6d0] bg-white text-[#1f8f6f]'
+              : 'border-[#f5d0d3] bg-white text-[#d15b64]'
+          }`}
+        >
+          <span className="text-[16px]">{toast.type === 'success' ? '\u2713' : '\u2717'}</span>
+          {toast.message}
+        </div>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/simulator/src/components/icons.tsx
+++ b/simulator/src/components/icons.tsx
@@ -1,0 +1,185 @@
+import type { SVGProps } from 'react';
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+function BaseIcon({ children, className, viewBox = '0 0 24 24', ...props }: IconProps & { viewBox?: string }) {
+  return (
+    <svg
+      viewBox={viewBox}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      {...props}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function SuiDropletIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M12 2.75C9.15 6.22 6.6 8.94 5.58 12.15A6.42 6.42 0 0 0 12 21.25a6.42 6.42 0 0 0 6.42-9.1C17.4 8.94 14.85 6.22 12 2.75Z" />
+      <path d="M9.6 14.5c.35 1.4 1.38 2.1 3.1 2.1 1.05 0 1.93-.3 2.65-.9" />
+    </BaseIcon>
+  );
+}
+
+export function PlaygroundIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <rect x="3.5" y="4.5" width="17" height="15" rx="2.5" />
+      <path d="M8 9.5h8" />
+      <path d="M8 13.5h5" />
+      <circle cx="17.25" cy="13.5" r="1.25" />
+    </BaseIcon>
+  );
+}
+
+export function CurriculumIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M6 4.5h12" />
+      <path d="M6 10h12" />
+      <path d="M6 15.5h7" />
+      <path d="M17.5 14.5v5" />
+      <path d="M15 17h5" />
+    </BaseIcon>
+  );
+}
+
+export function TerminalIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <rect x="3.5" y="4.5" width="17" height="15" rx="2.5" />
+      <path d="M7.25 9.25 10 12l-2.75 2.75" />
+      <path d="M12.5 15h4.25" />
+    </BaseIcon>
+  );
+}
+
+export function CompassIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="m14.85 9.15-1.65 4.05-4.05 1.65 1.65-4.05 4.05-1.65Z" />
+    </BaseIcon>
+  );
+}
+
+export function BridgeIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M4 17.5h16" />
+      <path d="M6 17.5V11c0-2.1 1.8-3.75 4-3.75s4 1.65 4 3.75v6.5" />
+      <path d="M10 17.5V12" />
+      <path d="M14 17.5V12" />
+    </BaseIcon>
+  );
+}
+
+export function ShieldWaveIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M12 3.25c2.55 1.55 4.8 2.32 6.75 2.32v5.25c0 4.2-2.7 7.55-6.75 9.93-4.05-2.38-6.75-5.73-6.75-9.93V5.57c1.95 0 4.2-.77 6.75-2.32Z" />
+      <path d="M8.75 11.5c1.1-1.25 2.26-1.88 3.48-1.88 1.18 0 2.19.43 3.02 1.28" />
+      <path d="M9.3 14.35c.82-.73 1.69-1.1 2.63-1.1.84 0 1.7.28 2.57.82" />
+    </BaseIcon>
+  );
+}
+
+export function StackIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="m12 3.75 8 4.25-8 4.25-8-4.25 8-4.25Z" />
+      <path d="m4 11.25 8 4.25 8-4.25" />
+      <path d="m4 15.5 8 4.25 8-4.25" />
+    </BaseIcon>
+  );
+}
+
+export function OrbitIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <circle cx="12" cy="12" r="1.75" />
+      <path d="M4.5 12c0-4.1 3.35-7.5 7.5-7.5 2.45 0 4.73 1.15 6.14 3.1" />
+      <path d="M19.5 12c0 4.1-3.35 7.5-7.5 7.5-2.45 0-4.73-1.15-6.14-3.1" />
+    </BaseIcon>
+  );
+}
+
+export function CameraResetIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M4.5 11.75a7.5 7.5 0 0 1 12.4-5.65" />
+      <path d="M18.5 6V2.75" />
+      <path d="M18.5 6h-3.25" />
+      <path d="M19.5 12.25A7.5 7.5 0 0 1 7.1 17.9" />
+      <path d="M5.5 18v3.25" />
+      <path d="M5.5 18h3.25" />
+    </BaseIcon>
+  );
+}
+
+export function GridIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <rect x="4" y="4" width="16" height="16" rx="2.5" />
+      <path d="M12 4v16" />
+      <path d="M4 12h16" />
+    </BaseIcon>
+  );
+}
+
+export function ArrowRightIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M5 12h14" />
+      <path d="m13 6 6 6-6 6" />
+    </BaseIcon>
+  );
+}
+
+export function ArrowLeftIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="M19 12H5" />
+      <path d="m11 6-6 6 6 6" />
+    </BaseIcon>
+  );
+}
+
+export function ClockIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="M12 7.5v5l3.25 1.75" />
+    </BaseIcon>
+  );
+}
+
+export function SparkIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <path d="m12 3.5 1.9 4.6 4.6 1.9-4.6 1.9L12 16.5l-1.9-4.6-4.6-1.9 4.6-1.9L12 3.5Z" />
+      <path d="m18.5 15.5.9 2.1 2.1.9-2.1.9-.9 2.1-.9-2.1-2.1-.9 2.1-.9.9-2.1Z" />
+    </BaseIcon>
+  );
+}
+
+export function HardwareIcon(props: IconProps) {
+  return (
+    <BaseIcon {...props}>
+      <rect x="5" y="7.5" width="14" height="9" rx="2.5" />
+      <path d="M9 7.5V5.25" />
+      <path d="M15 7.5V5.25" />
+      <circle cx="9" cy="12" r="1.2" />
+      <path d="M12 12h3" />
+    </BaseIcon>
+  );
+}

--- a/simulator/src/components/icons.tsx
+++ b/simulator/src/components/icons.tsx
@@ -21,11 +21,11 @@ function BaseIcon({ children, className, viewBox = '0 0 24 24', ...props }: Icon
   );
 }
 
-export function SuiDropletIcon(props: IconProps) {
+export function ChainIcon(props: IconProps) {
   return (
     <BaseIcon {...props}>
-      <path d="M12 2.75C9.15 6.22 6.6 8.94 5.58 12.15A6.42 6.42 0 0 0 12 21.25a6.42 6.42 0 0 0 6.42-9.1C17.4 8.94 14.85 6.22 12 2.75Z" />
-      <path d="M9.6 14.5c.35 1.4 1.38 2.1 3.1 2.1 1.05 0 1.93-.3 2.65-.9" />
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
     </BaseIcon>
   );
 }

--- a/simulator/src/hooks/useCommandHistory.ts
+++ b/simulator/src/hooks/useCommandHistory.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { onActionEvent, type ActionEvent } from '@/lib/action-events';
+
+const MAX_HISTORY = 20;
+
+export function useCommandHistory(): ActionEvent[] {
+  const [history, setHistory] = useState<ActionEvent[]>([]);
+
+  useEffect(() => {
+    return onActionEvent((event) => {
+      setHistory((prev) => {
+        const next = [event, ...prev];
+        return next.length > MAX_HISTORY ? next.slice(0, MAX_HISTORY) : next;
+      });
+    });
+  }, []);
+
+  return history;
+}

--- a/simulator/src/hooks/useCookieToken.ts
+++ b/simulator/src/hooks/useCookieToken.ts
@@ -1,0 +1,99 @@
+'use client';
+
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { DAppKitContext, useWalletConnection, useCurrentClient, useDAppKit } from '@mysten/dapp-kit-react';
+import { Transaction } from '@mysten/sui/transactions';
+import { COOKIE_CONTRACT } from '@/lib/sui-dapp-kit';
+import { showToast } from '@/components/Toast';
+
+const SUI_CLOCK = '0x6';
+
+interface CookieState {
+  balance: number;
+  isMinting: boolean;
+  isLoading: boolean;
+  mint: (amount?: number) => void;
+}
+
+const FALLBACK: CookieState = {
+  balance: 0,
+  isMinting: false,
+  isLoading: false,
+  mint: () => {},
+};
+
+export function useCookieToken(): CookieState {
+  const hasDAppKit = useContext(DAppKitContext) !== null;
+  if (!hasDAppKit) return FALLBACK;
+  return useCookieTokenInner();
+}
+
+function useCookieTokenInner(): CookieState {
+  const connection = useWalletConnection();
+  const client = useCurrentClient();
+  const dAppKit = useDAppKit();
+  const [balance, setBalance] = useState(0);
+  const [isMinting, setIsMinting] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchBalance = useCallback(async () => {
+    if (!connection.account || !client) return;
+    try {
+      setIsLoading(true);
+      const coins = await client.listCoins({
+        owner: connection.account.address,
+        coinType: COOKIE_CONTRACT.coinType,
+      });
+      const total = coins.objects.reduce((sum: number, c) => sum + Number(c.balance), 0);
+      setBalance(total);
+    } catch {
+      // Token might not exist for this user yet
+    } finally {
+      setIsLoading(false);
+    }
+  }, [connection.account, client]);
+
+  useEffect(() => {
+    if (!connection.account) return;
+    fetchBalance();
+    timerRef.current = setInterval(fetchBalance, 10_000);
+    return () => { if (timerRef.current) clearInterval(timerRef.current); };
+  }, [connection.account, fetchBalance]);
+
+  const mint = useCallback(
+    (amount = 100) => {
+      if (!connection.account || isMinting) return;
+      setIsMinting(true);
+
+      const tx = new Transaction();
+      tx.moveCall({
+        target: `${COOKIE_CONTRACT.packageId}::cookie::mint`,
+        arguments: [
+          tx.object(COOKIE_CONTRACT.faucetId),
+          tx.pure.u64(amount),
+          tx.object(SUI_CLOCK),
+        ],
+      });
+
+      dAppKit
+        .signAndExecuteTransaction({ transaction: tx })
+        .then((result) => {
+          if (result.$kind === 'FailedTransaction') {
+            showToast('error', 'Mint failed');
+            return;
+          }
+          showToast('success', `Minted ${amount} COOKIE`);
+          setTimeout(fetchBalance, 2000);
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          showToast('error', msg.length > 50 ? msg.slice(0, 50) + '...' : msg);
+        })
+        .finally(() => setIsMinting(false));
+    },
+    [connection.account, isMinting, dAppKit, fetchBalance],
+  );
+
+  return { balance, isMinting, isLoading, mint };
+}

--- a/simulator/src/hooks/useOnChainAction.ts
+++ b/simulator/src/hooks/useOnChainAction.ts
@@ -6,6 +6,7 @@ import { Transaction } from '@mysten/sui/transactions';
 import { useSimulator } from '@/hooks/useSimulator';
 import { SUI_CONTRACT, isOnChainConfigured } from '@/lib/sui-dapp-kit';
 import { showToast } from '@/components/Toast';
+import { emitActionEvent } from '@/lib/action-events';
 
 const SUI_CLOCK_OBJECT = '0x6';
 
@@ -73,14 +74,17 @@ function useOnChainActionInner() {
 
           // Tx confirmed — now animate the robot
           sendAction(action);
-          const short = result.Transaction.digest.slice(0, 10);
+          const digest = result.Transaction.digest;
+          const short = digest.slice(0, 10);
           addTerminalLog('ok', `\u2713 Confirmed: ${short}...`);
           showToast('success', `${action} confirmed on-chain`);
+          emitActionEvent({ action, txDigest: digest, timestamp: Date.now(), status: 'confirmed' });
         })
         .catch((err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err);
           addTerminalLog('error', `\u2717 Failed: ${msg}`);
           showToast('error', msg.length > 60 ? msg.slice(0, 60) + '...' : msg);
+          emitActionEvent({ action, txDigest: '', timestamp: Date.now(), status: 'failed' });
         })
         .finally(() => {
           pendingRef.current -= 1;

--- a/simulator/src/hooks/useOnChainAction.ts
+++ b/simulator/src/hooks/useOnChainAction.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useCallback, useContext, useRef, useState } from 'react';
+import { DAppKitContext, useWalletConnection, useDAppKit } from '@mysten/dapp-kit-react';
+import { Transaction } from '@mysten/sui/transactions';
+import { useSimulator } from '@/hooks/useSimulator';
+import { SUI_CONTRACT, isOnChainConfigured } from '@/lib/sui-dapp-kit';
+
+const SUI_CLOCK_OBJECT = '0x6';
+
+const FALLBACK = {
+  sendActionWithChain: (_action: string) => {},
+  pendingTxCount: 0,
+  isWalletConnected: false,
+  isOnChainConfigured: false,
+} as const;
+
+export function useOnChainAction() {
+  const hasDAppKit = useContext(DAppKitContext) !== null;
+
+  if (!hasDAppKit) {
+    // During SSR or when provider is missing, fall back to local-only
+    return { ...FALLBACK, sendActionWithChain: useSimulatorFallback() };
+  }
+
+  return useOnChainActionInner();
+}
+
+/** Bare local-only fallback that only needs SimulatorProvider */
+function useSimulatorFallback() {
+  const { sendAction } = useSimulator();
+  return useCallback((action: string) => sendAction(action), [sendAction]);
+}
+
+/** Full implementation — only called when DAppKitContext is available */
+function useOnChainActionInner() {
+  const { sendAction, addTerminalLog } = useSimulator();
+  const connection = useWalletConnection();
+  const dAppKit = useDAppKit();
+  const configured = isOnChainConfigured();
+  const [pendingTxCount, setPendingTxCount] = useState(0);
+  const pendingRef = useRef(0);
+
+  const sendActionWithChain = useCallback(
+    (action: string) => {
+      // Path A: WebSocket (immediate)
+      sendAction(action);
+
+      // Path B: On-chain (async, non-blocking)
+      if (!connection.account || !configured) return;
+
+      addTerminalLog('info', `\u26D3 Submitting "${action}"...`);
+      pendingRef.current += 1;
+      setPendingTxCount(pendingRef.current);
+
+      const tx = new Transaction();
+      tx.moveCall({
+        target: `${SUI_CONTRACT.packageId}::robot_queue::add_action`,
+        arguments: [
+          tx.object(SUI_CONTRACT.queueId),
+          tx.pure.string(action),
+          tx.object(SUI_CLOCK_OBJECT),
+        ],
+      });
+
+      dAppKit
+        .signAndExecuteTransaction({ transaction: tx })
+        .then((result) => {
+          if (result.$kind === 'FailedTransaction') {
+            addTerminalLog('error', `\u2717 Transaction failed on-chain`);
+            return;
+          }
+          const short = result.Transaction.digest.slice(0, 10);
+          addTerminalLog('ok', `\u2713 Confirmed: ${short}...`);
+        })
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          addTerminalLog('error', `\u2717 Failed: ${msg}`);
+        })
+        .finally(() => {
+          pendingRef.current -= 1;
+          setPendingTxCount(pendingRef.current);
+        });
+    },
+    [sendAction, addTerminalLog, connection.account, configured, dAppKit],
+  );
+
+  return {
+    sendActionWithChain,
+    pendingTxCount,
+    isWalletConnected: !!connection.account,
+    isOnChainConfigured: configured,
+  };
+}

--- a/simulator/src/hooks/useOnChainAction.ts
+++ b/simulator/src/hooks/useOnChainAction.ts
@@ -5,6 +5,7 @@ import { DAppKitContext, useWalletConnection, useDAppKit } from '@mysten/dapp-ki
 import { Transaction } from '@mysten/sui/transactions';
 import { useSimulator } from '@/hooks/useSimulator';
 import { SUI_CONTRACT, isOnChainConfigured } from '@/lib/sui-dapp-kit';
+import { showToast } from '@/components/Toast';
 
 const SUI_CLOCK_OBJECT = '0x6';
 
@@ -19,20 +20,17 @@ export function useOnChainAction() {
   const hasDAppKit = useContext(DAppKitContext) !== null;
 
   if (!hasDAppKit) {
-    // During SSR or when provider is missing, fall back to local-only
     return { ...FALLBACK, sendActionWithChain: useSimulatorFallback() };
   }
 
   return useOnChainActionInner();
 }
 
-/** Bare local-only fallback that only needs SimulatorProvider */
 function useSimulatorFallback() {
   const { sendAction } = useSimulator();
   return useCallback((action: string) => sendAction(action), [sendAction]);
 }
 
-/** Full implementation — only called when DAppKitContext is available */
 function useOnChainActionInner() {
   const { sendAction, addTerminalLog } = useSimulator();
   const connection = useWalletConnection();
@@ -43,13 +41,14 @@ function useOnChainActionInner() {
 
   const sendActionWithChain = useCallback(
     (action: string) => {
-      // Path A: WebSocket (immediate)
-      sendAction(action);
+      // No wallet or contract not configured — local-only, animate immediately
+      if (!connection.account || !configured) {
+        sendAction(action);
+        return;
+      }
 
-      // Path B: On-chain (async, non-blocking)
-      if (!connection.account || !configured) return;
-
-      addTerminalLog('info', `\u26D3 Submitting "${action}"...`);
+      // Wallet connected: sign tx FIRST, then animate on success
+      addTerminalLog('info', `\u26D3 Signing "${action}"...`);
       pendingRef.current += 1;
       setPendingTxCount(pendingRef.current);
 
@@ -68,14 +67,20 @@ function useOnChainActionInner() {
         .then((result) => {
           if (result.$kind === 'FailedTransaction') {
             addTerminalLog('error', `\u2717 Transaction failed on-chain`);
+            showToast('error', `Transaction failed`);
             return;
           }
+
+          // Tx confirmed — now animate the robot
+          sendAction(action);
           const short = result.Transaction.digest.slice(0, 10);
           addTerminalLog('ok', `\u2713 Confirmed: ${short}...`);
+          showToast('success', `${action} confirmed on-chain`);
         })
         .catch((err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err);
           addTerminalLog('error', `\u2717 Failed: ${msg}`);
+          showToast('error', msg.length > 60 ? msg.slice(0, 60) + '...' : msg);
         })
         .finally(() => {
           pendingRef.current -= 1;

--- a/simulator/src/hooks/useOnChainQueue.ts
+++ b/simulator/src/hooks/useOnChainQueue.ts
@@ -1,0 +1,79 @@
+'use client';
+
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { DAppKitContext, useWalletConnection, useCurrentClient } from '@mysten/dapp-kit-react';
+import { SUI_CONTRACT, isOnChainConfigured } from '@/lib/sui-dapp-kit';
+
+interface QueueState {
+  queueLength: number;
+  totalActionsAdded: number;
+  totalActionsProcessed: number;
+  isLoading: boolean;
+}
+
+const POLL_INTERVAL = 5000;
+
+const DEFAULT_STATE: QueueState = {
+  queueLength: 0,
+  totalActionsAdded: 0,
+  totalActionsProcessed: 0,
+  isLoading: false,
+};
+
+export function useOnChainQueue(): QueueState {
+  const hasDAppKit = useContext(DAppKitContext) !== null;
+
+  if (!hasDAppKit) {
+    return DEFAULT_STATE;
+  }
+
+  return useOnChainQueueInner();
+}
+
+function useOnChainQueueInner(): QueueState {
+  const [state, setState] = useState<QueueState>(DEFAULT_STATE);
+  const connection = useWalletConnection();
+  const client = useCurrentClient();
+  const configured = isOnChainConfigured();
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchQueue = useCallback(async () => {
+    if (!configured || !client) return;
+
+    try {
+      setState((prev) => ({ ...prev, isLoading: true }));
+      const result = await client.getObject({
+        objectId: SUI_CONTRACT.queueId,
+        include: { json: true },
+      });
+
+      const fields = result.object.json;
+      if (fields) {
+        const actions = fields.actions;
+        setState({
+          queueLength: Array.isArray(actions) ? actions.length : 0,
+          totalActionsAdded: Number(fields.total_actions_added ?? 0),
+          totalActionsProcessed: Number(fields.total_actions_processed ?? 0),
+          isLoading: false,
+        });
+      } else {
+        setState((prev) => ({ ...prev, isLoading: false }));
+      }
+    } catch {
+      setState((prev) => ({ ...prev, isLoading: false }));
+    }
+  }, [configured, client]);
+
+  useEffect(() => {
+    if (!configured || !connection.account) return;
+
+    fetchQueue();
+    timerRef.current = setInterval(fetchQueue, POLL_INTERVAL);
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [configured, connection.account, fetchQueue]);
+
+  return state;
+}

--- a/simulator/src/hooks/useSessionTracker.ts
+++ b/simulator/src/hooks/useSessionTracker.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const SESSION_DURATION_MS = 600_000; // 10 minutes (matches R10 rental)
+
+export interface SessionState {
+  sessionId: string;
+  startTime: number;
+  timeRemainingMs: number;
+  sequenceNumber: number;
+  commandsUsed: number;
+  isActive: boolean;
+  pricePerMinute: number;
+  estimatedCost: number;
+}
+
+const INACTIVE: SessionState = {
+  sessionId: '—',
+  startTime: 0,
+  timeRemainingMs: SESSION_DURATION_MS,
+  sequenceNumber: 0,
+  commandsUsed: 0,
+  isActive: false,
+  pricePerMinute: 2,
+  estimatedCost: 0,
+};
+
+export function useSessionTracker(isWalletConnected: boolean, commandsExecuted: number): SessionState {
+  const [state, setState] = useState<SessionState>(INACTIVE);
+  const startRef = useRef(0);
+  const prevCmdsRef = useRef(0);
+
+  // Start session on first command after wallet connect
+  useEffect(() => {
+    if (!isWalletConnected) {
+      setState(INACTIVE);
+      startRef.current = 0;
+      prevCmdsRef.current = 0;
+      return;
+    }
+
+    if (commandsExecuted > prevCmdsRef.current && startRef.current === 0) {
+      startRef.current = Date.now();
+      // Deterministic session ID from timestamp
+      const id = '0x' + startRef.current.toString(16).padStart(16, '0') + 'a'.repeat(48);
+      setState((s) => ({ ...s, sessionId: id, startTime: startRef.current, isActive: true }));
+    }
+    prevCmdsRef.current = commandsExecuted;
+  }, [isWalletConnected, commandsExecuted]);
+
+  // Tick countdown + update stats
+  useEffect(() => {
+    if (!state.isActive) return;
+    const id = setInterval(() => {
+      const elapsed = Date.now() - startRef.current;
+      const remaining = Math.max(0, SESSION_DURATION_MS - elapsed);
+      const minutes = elapsed / 60_000;
+      setState((s) => ({
+        ...s,
+        timeRemainingMs: remaining,
+        sequenceNumber: prevCmdsRef.current,
+        commandsUsed: prevCmdsRef.current,
+        estimatedCost: Math.ceil(minutes) * s.pricePerMinute,
+        isActive: remaining > 0,
+      }));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [state.isActive]);
+
+  return state;
+}

--- a/simulator/src/hooks/useSimulator.tsx
+++ b/simulator/src/hooks/useSimulator.tsx
@@ -60,6 +60,8 @@ interface SimulatorContextValue {
   robotState: RobotState | null;
   connectionStatus: ConnectionStatus;
   terminalLogs: TerminalEntry[];
+  latencyMs: number | null;
+  connectedClients: number;
   sendCommand: (cmd: string) => void;
   sendAction: (action: string) => void;
   addTerminalLog: (type: TerminalEntry['type'], message: string) => void;
@@ -117,10 +119,13 @@ export function SimulatorProvider({ children }: { children: ReactNode }) {
   const [robotState, setRobotState] = useState<RobotState | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected');
   const [terminalLogs, setTerminalLogs] = useState<TerminalEntry[]>([]);
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [connectedClients, setConnectedClients] = useState(1);
 
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptRef = useRef(0);
+  const pingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const addTerminalLog = useCallback((type: TerminalEntry['type'], message: string) => {
     setTerminalLogs((prev) => {
@@ -151,11 +156,29 @@ export function SimulatorProvider({ children }: { children: ReactNode }) {
       setConnectionStatus('connected');
       reconnectAttemptRef.current = 0;
       addTerminalLog('system', 'Connected to simulator server');
+
+      // Start ping interval for latency measurement (R5)
+      if (pingTimerRef.current) clearInterval(pingTimerRef.current);
+      pingTimerRef.current = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'ping', ts: Date.now() }));
+        }
+      }, 3000);
     };
 
     ws.onmessage = (event) => {
       try {
         const msg = JSON.parse(event.data);
+
+        if (msg.type === 'pong' && msg.ts) {
+          setLatencyMs(Date.now() - msg.ts);
+          return;
+        }
+
+        if (msg.type === 'clients_update') {
+          setConnectedClients(msg.count);
+          return;
+        }
 
         if (msg.type === 'state') {
           setRobotState(msg.data);
@@ -197,6 +220,8 @@ export function SimulatorProvider({ children }: { children: ReactNode }) {
     ws.onclose = () => {
       setConnectionStatus('disconnected');
       wsRef.current = null;
+      setLatencyMs(null);
+      if (pingTimerRef.current) clearInterval(pingTimerRef.current);
       addTerminalLog('system', 'Disconnected from server');
 
       // Auto-reconnect with exponential backoff
@@ -253,6 +278,8 @@ export function SimulatorProvider({ children }: { children: ReactNode }) {
         robotState: robotState ?? DEFAULT_STATE,
         connectionStatus,
         terminalLogs,
+        latencyMs,
+        connectedClients,
         sendCommand,
         sendAction,
         addTerminalLog,

--- a/simulator/src/hooks/useSimulator.tsx
+++ b/simulator/src/hooks/useSimulator.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+  type ReactNode,
+} from 'react';
+
+// ── Types ─────────────────────────────────────────────────────
+
+export interface JointAngles {
+  headPitch: number;
+  headYaw: number;
+  tailWag: number;
+  frontLeftHip: number;
+  frontLeftKnee: number;
+  frontRightHip: number;
+  frontRightKnee: number;
+  backLeftHip: number;
+  backLeftKnee: number;
+  backRightHip: number;
+  backRightKnee: number;
+}
+
+export interface RobotState {
+  action: string;
+  actionLabel: string;
+  joints: JointAngles;
+  bodyHeight: number;
+  bodyPitch: number;
+  bodyRoll: number;
+  moving: boolean;
+  walkCycle: number;
+  mood: string;
+  battery: number;
+  uptime: number;
+  commandsExecuted: number;
+}
+
+export interface RobotEvent {
+  type: string;
+  action?: string;
+  message: string;
+  timestamp: number;
+}
+
+export interface TerminalEntry {
+  type: 'info' | 'cmd' | 'ok' | 'error' | 'event' | 'system';
+  message: string;
+  time: string;
+}
+
+type ConnectionStatus = 'connecting' | 'connected' | 'disconnected';
+
+interface SimulatorContextValue {
+  robotState: RobotState | null;
+  connectionStatus: ConnectionStatus;
+  terminalLogs: TerminalEntry[];
+  sendCommand: (cmd: string) => void;
+  sendAction: (action: string) => void;
+  addTerminalLog: (type: TerminalEntry['type'], message: string) => void;
+  clearTerminalLogs: () => void;
+}
+
+// ── Default state ─────────────────────────────────────────────
+
+const DEFAULT_JOINTS: JointAngles = {
+  headPitch: 0,
+  headYaw: 0,
+  tailWag: 0,
+  frontLeftHip: 0,
+  frontLeftKnee: 0,
+  frontRightHip: 0,
+  frontRightKnee: 0,
+  backLeftHip: 0,
+  backLeftKnee: 0,
+  backRightHip: 0,
+  backRightKnee: 0,
+};
+
+const DEFAULT_STATE: RobotState = {
+  action: 'idle',
+  actionLabel: 'Idle',
+  joints: { ...DEFAULT_JOINTS },
+  bodyHeight: 0,
+  bodyPitch: 0,
+  bodyRoll: 0,
+  moving: false,
+  walkCycle: 0,
+  mood: 'neutral',
+  battery: 100,
+  uptime: 0,
+  commandsExecuted: 0,
+};
+
+// ── Context ───────────────────────────────────────────────────
+
+const SimulatorContext = createContext<SimulatorContextValue | null>(null);
+
+function formatTime(): string {
+  const now = new Date();
+  return now.toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+// ── Provider ──────────────────────────────────────────────────
+
+export function SimulatorProvider({ children }: { children: ReactNode }) {
+  const [robotState, setRobotState] = useState<RobotState | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected');
+  const [terminalLogs, setTerminalLogs] = useState<TerminalEntry[]>([]);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptRef = useRef(0);
+
+  const addTerminalLog = useCallback((type: TerminalEntry['type'], message: string) => {
+    setTerminalLogs((prev) => {
+      const next = [...prev, { type, message, time: formatTime() }];
+      // Keep the last 500 entries
+      if (next.length > 500) return next.slice(-500);
+      return next;
+    });
+  }, []);
+
+  const clearTerminalLogs = useCallback(() => {
+    setTerminalLogs([]);
+  }, []);
+
+  const connect = useCallback(() => {
+    // Determine WebSocket URL based on current location
+    const protocol = typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const host = typeof window !== 'undefined' ? window.location.host : 'localhost:3000';
+    const wsUrl = `${protocol}//${host}/ws`;
+
+    setConnectionStatus('connecting');
+    addTerminalLog('system', `Connecting to ${wsUrl}...`);
+
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setConnectionStatus('connected');
+      reconnectAttemptRef.current = 0;
+      addTerminalLog('system', 'Connected to simulator server');
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+
+        if (msg.type === 'state') {
+          setRobotState(msg.data);
+          if (msg.event) {
+            const evt = msg.event as RobotEvent;
+            if (evt.type === 'error') {
+              addTerminalLog('error', evt.message);
+            } else if (evt.type === 'state_change') {
+              addTerminalLog('event', evt.message);
+            } else {
+              addTerminalLog('info', evt.message);
+            }
+          } else {
+            addTerminalLog('info', 'Received initial state');
+          }
+        } else if (msg.type === 'event') {
+          setRobotState(msg.state);
+          if (msg.event) {
+            const evt = msg.event as RobotEvent;
+            if (evt.type === 'error') {
+              addTerminalLog('error', evt.message);
+            } else if (evt.type === 'state_change') {
+              addTerminalLog('event', evt.message);
+            } else {
+              addTerminalLog('info', evt.message);
+            }
+          }
+        } else if (msg.type === 'ack' || msg.type === 'command_ack') {
+          addTerminalLog('ok', msg.result);
+        } else if (msg.type === 'error') {
+          addTerminalLog('error', msg.message);
+        }
+      } catch {
+        // Non-JSON messages
+        addTerminalLog('info', event.data);
+      }
+    };
+
+    ws.onclose = () => {
+      setConnectionStatus('disconnected');
+      wsRef.current = null;
+      addTerminalLog('system', 'Disconnected from server');
+
+      // Auto-reconnect with exponential backoff
+      const delay = Math.min(1000 * Math.pow(2, reconnectAttemptRef.current), 10000);
+      reconnectAttemptRef.current++;
+      addTerminalLog('system', `Reconnecting in ${(delay / 1000).toFixed(1)}s...`);
+      reconnectTimerRef.current = setTimeout(connect, delay);
+    };
+
+    ws.onerror = () => {
+      addTerminalLog('error', 'WebSocket error');
+    };
+  }, [addTerminalLog]);
+
+  useEffect(() => {
+    connect();
+    return () => {
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+      }
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, [connect]);
+
+  const sendCommand = useCallback(
+    (cmd: string) => {
+      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+        addTerminalLog('cmd', `> ${cmd}`);
+        wsRef.current.send(JSON.stringify({ type: 'command', command: cmd }));
+      } else {
+        addTerminalLog('error', 'Not connected to server');
+      }
+    },
+    [addTerminalLog]
+  );
+
+  const sendAction = useCallback(
+    (action: string) => {
+      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+        addTerminalLog('cmd', `action: ${action}`);
+        wsRef.current.send(JSON.stringify({ type: 'action', action }));
+      } else {
+        addTerminalLog('error', 'Not connected to server');
+      }
+    },
+    [addTerminalLog]
+  );
+
+  return (
+    <SimulatorContext.Provider
+      value={{
+        robotState: robotState ?? DEFAULT_STATE,
+        connectionStatus,
+        terminalLogs,
+        sendCommand,
+        sendAction,
+        addTerminalLog,
+        clearTerminalLogs,
+      }}
+    >
+      {children}
+    </SimulatorContext.Provider>
+  );
+}
+
+// ── Hook ──────────────────────────────────────────────────────
+
+export function useSimulator(): SimulatorContextValue {
+  const ctx = useContext(SimulatorContext);
+  if (!ctx) {
+    throw new Error('useSimulator must be used within a SimulatorProvider');
+  }
+  return ctx;
+}

--- a/simulator/src/lib/action-events.ts
+++ b/simulator/src/lib/action-events.ts
@@ -1,0 +1,24 @@
+/**
+ * Lightweight typed pub/sub for action events.
+ * useOnChainAction publishes here; useCommandHistory subscribes.
+ */
+
+export interface ActionEvent {
+  action: string;
+  txDigest: string;
+  timestamp: number;
+  status: 'confirmed' | 'failed';
+}
+
+type Listener = (event: ActionEvent) => void;
+
+const listeners = new Set<Listener>();
+
+export function emitActionEvent(event: ActionEvent) {
+  for (const fn of listeners) fn(event);
+}
+
+export function onActionEvent(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}

--- a/simulator/src/lib/camera/robot-cameras.ts
+++ b/simulator/src/lib/camera/robot-cameras.ts
@@ -1,0 +1,92 @@
+/**
+ * Robot Camera Simulation
+ *
+ * Creates 5 PerspectiveCamera objects matching the GO1's camera positions
+ * from the URDF, renders them to off-screen render targets, and provides
+ * utilities to copy the output to canvas elements for PiP display.
+ */
+
+import * as THREE from 'three';
+import { CAMERAS } from '../unitree-go1';
+
+const CAM_WIDTH = 160;
+const CAM_HEIGHT = 120;
+
+export interface RobotCameraRig {
+  cameras: THREE.PerspectiveCamera[];
+  renderTargets: THREE.WebGLRenderTarget[];
+  names: string[];
+  renderCamera: (index: number, renderer: THREE.WebGLRenderer, scene: THREE.Scene) => void;
+  copyToCanvas: (index: number, renderer: THREE.WebGLRenderer, canvas: HTMLCanvasElement) => void;
+  dispose: () => void;
+}
+
+export function createRobotCameraRig(bodyBone: THREE.Object3D): RobotCameraRig {
+  const cameras: THREE.PerspectiveCamera[] = [];
+  const renderTargets: THREE.WebGLRenderTarget[] = [];
+  const names: string[] = [];
+  const pixelBuffer = new Uint8Array(CAM_WIDTH * CAM_HEIGHT * 4);
+
+  for (const camDef of CAMERAS) {
+    const cam = new THREE.PerspectiveCamera(70, CAM_WIDTH / CAM_HEIGHT, 0.01, 10);
+    cam.position.set(camDef.position.x, camDef.position.z, -camDef.position.y);
+
+    // Orient cameras based on their position
+    if (camDef.name === 'face' || camDef.name === 'chin') {
+      cam.lookAt(cam.position.x + 1, cam.position.y, cam.position.z);
+    } else if (camDef.name === 'left') {
+      cam.lookAt(cam.position.x, cam.position.y, cam.position.z + 1);
+    } else if (camDef.name === 'right') {
+      cam.lookAt(cam.position.x, cam.position.y, cam.position.z - 1);
+    } else if (camDef.name === 'rearDown') {
+      cam.lookAt(cam.position.x - 1, cam.position.y - 0.5, cam.position.z);
+    }
+
+    bodyBone.add(cam);
+    cameras.push(cam);
+    names.push(camDef.name);
+
+    const rt = new THREE.WebGLRenderTarget(CAM_WIDTH, CAM_HEIGHT, {
+      format: THREE.RGBAFormat,
+      type: THREE.UnsignedByteType,
+    });
+    renderTargets.push(rt);
+  }
+
+  function renderCamera(index: number, renderer: THREE.WebGLRenderer, scene: THREE.Scene) {
+    if (index < 0 || index >= cameras.length) return;
+    renderer.setRenderTarget(renderTargets[index]);
+    renderer.render(scene, cameras[index]);
+    renderer.setRenderTarget(null);
+  }
+
+  function copyToCanvas(index: number, renderer: THREE.WebGLRenderer, canvas: HTMLCanvasElement) {
+    if (index < 0 || index >= cameras.length) return;
+    renderer.readRenderTargetPixels(renderTargets[index], 0, 0, CAM_WIDTH, CAM_HEIGHT, pixelBuffer);
+
+    canvas.width = CAM_WIDTH;
+    canvas.height = CAM_HEIGHT;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const imageData = ctx.createImageData(CAM_WIDTH, CAM_HEIGHT);
+    // Flip vertically (WebGL reads bottom-up)
+    for (let y = 0; y < CAM_HEIGHT; y++) {
+      const srcRow = (CAM_HEIGHT - 1 - y) * CAM_WIDTH * 4;
+      const dstRow = y * CAM_WIDTH * 4;
+      for (let x = 0; x < CAM_WIDTH * 4; x++) {
+        imageData.data[dstRow + x] = pixelBuffer[srcRow + x];
+      }
+    }
+    ctx.putImageData(imageData, 0, 0);
+  }
+
+  function dispose() {
+    for (const rt of renderTargets) rt.dispose();
+    for (const cam of cameras) {
+      cam.removeFromParent();
+    }
+  }
+
+  return { cameras, renderTargets, names, renderCamera, copyToCanvas, dispose };
+}

--- a/simulator/src/lib/controller/unitree-sdk.ts
+++ b/simulator/src/lib/controller/unitree-sdk.ts
@@ -1,0 +1,155 @@
+/**
+ * Unitree Legged SDK — TypeScript Interface
+ *
+ * Mirrors the C++ unitree_legged_sdk API so that controller code
+ * written against this interface can be ported to/from the real SDK.
+ *
+ * Reference: github.com/unitreerobotics/unitree_legged_sdk
+ */
+
+// ── Joint index enum (matches SDK ordering) ──────────────────
+
+export enum JointIndex {
+  FR_0 = 0,  // FR hip roll
+  FR_1 = 1,  // FR thigh pitch
+  FR_2 = 2,  // FR calf pitch
+  FL_0 = 3,  // FL hip roll
+  FL_1 = 4,  // FL thigh pitch
+  FL_2 = 5,  // FL calf pitch
+  RR_0 = 6,  // RR hip roll
+  RR_1 = 7,  // RR thigh pitch
+  RR_2 = 8,  // RR calf pitch
+  RL_0 = 9,  // RL hip roll
+  RL_1 = 10, // RL thigh pitch
+  RL_2 = 11, // RL calf pitch
+}
+
+// ── Motor command (per joint) ────────────────────────────────
+
+export interface MotorCmd {
+  mode: number;   // 0 = idle, 10 = servo (position control)
+  q: number;      // target position (rad)
+  dq: number;     // target velocity (rad/s)
+  tau: number;    // feedforward torque (Nm)
+  Kp: number;     // position gain
+  Kd: number;     // velocity gain
+}
+
+// ── Low-level command (all 12 joints) ────────────────────────
+
+export interface LowCmd {
+  motorCmd: MotorCmd[];  // 12 entries indexed by JointIndex
+}
+
+// ── Motor state (per joint) ──────────────────────────────────
+
+export interface MotorState {
+  q: number;          // current position (rad)
+  dq: number;         // current velocity (rad/s)
+  tauEst: number;     // estimated torque (Nm)
+  temperature: number; // degrees C (simulated)
+}
+
+// ── IMU state ────────────────────────────────────────────────
+
+export interface IMUState {
+  quaternion: [number, number, number, number]; // w, x, y, z
+  gyroscope: [number, number, number];          // rad/s
+  accelerometer: [number, number, number];       // m/s^2
+  rpy: [number, number, number];                 // roll, pitch, yaw (rad)
+}
+
+// ── Low-level state (full robot) ─────────────────────────────
+
+export interface LowState {
+  motorState: MotorState[];  // 12 entries
+  imu: IMUState;
+  footForce: [number, number, number, number]; // FR, FL, RR, RL (N)
+  tick: number;              // simulation timestep count
+}
+
+// ── Default motor command ────────────────────────────────────
+
+export function defaultMotorCmd(): MotorCmd {
+  return { mode: 0, q: 0, dq: 0, tau: 0, Kp: 0, Kd: 0 };
+}
+
+export function defaultLowCmd(): LowCmd {
+  return { motorCmd: Array.from({ length: 12 }, defaultMotorCmd) };
+}
+
+// ── Simulated controller ─────────────────────────────────────
+
+/**
+ * Software-simulated Unitree controller.
+ *
+ * When Rapier physics is available, motor commands drive Rapier joint
+ * motors and state is read back from the physics world. Without Rapier,
+ * the controller tracks target angles in software and reports them
+ * directly (no dynamics simulation).
+ */
+export class UnitreeController {
+  private jointPositions = new Float64Array(12);
+  private jointVelocities = new Float64Array(12);
+  private jointTorques = new Float64Array(12);
+  private targetPositions = new Float64Array(12);
+  private tick = 0;
+
+  /** Apply motor commands. In software mode, this sets targets directly. */
+  sendLowCmd(cmd: LowCmd): void {
+    for (let i = 0; i < 12; i++) {
+      const mc = cmd.motorCmd[i];
+      if (mc.mode === 10) {
+        this.targetPositions[i] = mc.q;
+      }
+    }
+  }
+
+  /** Step the controller (called at control rate, e.g., per physics tick). */
+  step(dt: number): void {
+    this.tick++;
+    // Simple PD simulation without Rapier
+    for (let i = 0; i < 12; i++) {
+      const error = this.targetPositions[i] - this.jointPositions[i];
+      const Kp = 50;
+      const Kd = 2;
+      const accel = Kp * error - Kd * this.jointVelocities[i];
+      this.jointVelocities[i] += accel * dt;
+      this.jointPositions[i] += this.jointVelocities[i] * dt;
+      this.jointTorques[i] = Kp * error;
+    }
+  }
+
+  /** Read current state. */
+  getLowState(): LowState {
+    return {
+      motorState: Array.from({ length: 12 }, (_, i) => ({
+        q: this.jointPositions[i],
+        dq: this.jointVelocities[i],
+        tauEst: this.jointTorques[i],
+        temperature: 35 + Math.random() * 5,
+      })),
+      imu: {
+        quaternion: [1, 0, 0, 0],
+        gyroscope: [0, 0, 0],
+        accelerometer: [0, 0, -9.81],
+        rpy: [0, 0, 0],
+      },
+      footForce: [0, 0, 0, 0],
+      tick: this.tick,
+    };
+  }
+
+  /** Get all 12 joint positions as a flat array. */
+  getJointPositions(): Float64Array {
+    return this.jointPositions;
+  }
+
+  /** Set joint positions directly (for kinematic mode). */
+  setJointPositions(positions: ArrayLike<number>): void {
+    for (let i = 0; i < 12 && i < positions.length; i++) {
+      this.jointPositions[i] = positions[i];
+      this.targetPositions[i] = positions[i];
+    }
+  }
+}

--- a/simulator/src/lib/kinematics/forward-kinematics.ts
+++ b/simulator/src/lib/kinematics/forward-kinematics.ts
@@ -1,0 +1,64 @@
+/**
+ * Forward Kinematics for the Unitree GO1
+ *
+ * Computes foot position in trunk frame given 3 joint angles per leg.
+ * Uses the kinematic dimensions from the URDF (unitree-go1.ts).
+ */
+
+import { GO1_DIMENSIONS, HIP_ORIGINS, type LegPrefix } from '../unitree-go1';
+
+const { thighLength: L1, calfLength: L2, thighOffset: D } = GO1_DIMENSIONS;
+
+/**
+ * Compute foot position in trunk frame for one leg.
+ *
+ * @param leg     - Which leg (FR, FL, RR, RL)
+ * @param hipRoll - Hip roll angle in radians (rotation around X-axis)
+ * @param thigh   - Thigh pitch angle in radians (rotation around Y-axis)
+ * @param calf    - Calf pitch angle in radians (rotation around Y-axis)
+ * @returns       - [x, y, z] foot position in trunk frame (meters)
+ */
+export function legFK(
+  leg: LegPrefix,
+  hipRoll: number,
+  thigh: number,
+  calf: number,
+): [number, number, number] {
+  const origin = HIP_ORIGINS[leg];
+  const sideSign = leg === 'FL' || leg === 'RL' ? 1 : -1;
+
+  // Hip roll rotates the leg plane around X
+  const cr = Math.cos(hipRoll);
+  const sr = Math.sin(hipRoll);
+
+  // Thigh + calf pitch in the sagittal plane
+  const kneeAngle = thigh + calf;
+  const dx = -L1 * Math.sin(thigh) - L2 * Math.sin(kneeAngle);
+  const dz = -L1 * Math.cos(thigh) - L2 * Math.cos(kneeAngle);
+
+  // Lateral offset from hip roll
+  const lateralOffset = sideSign * D;
+  const dy = lateralOffset * cr - dz * sr;
+  const dzFinal = lateralOffset * sr + dz * cr;
+
+  return [
+    origin.x + dx,
+    origin.y + dy,
+    origin.z + dzFinal,
+  ];
+}
+
+/**
+ * Compute all 4 foot positions given 12 joint angles.
+ *
+ * @param angles - Array of 12 angles in order: [FR_hip, FR_thigh, FR_calf, FL_..., RR_..., RL_...]
+ * @returns      - Object with foot positions for each leg
+ */
+export function allFeetFK(angles: number[]): Record<LegPrefix, [number, number, number]> {
+  return {
+    FR: legFK('FR', angles[0], angles[1], angles[2]),
+    FL: legFK('FL', angles[3], angles[4], angles[5]),
+    RR: legFK('RR', angles[6], angles[7], angles[8]),
+    RL: legFK('RL', angles[9], angles[10], angles[11]),
+  };
+}

--- a/simulator/src/lib/kinematics/inverse-kinematics.ts
+++ b/simulator/src/lib/kinematics/inverse-kinematics.ts
@@ -1,0 +1,100 @@
+/**
+ * Analytical Inverse Kinematics for the Unitree GO1
+ *
+ * Solves the 3-DOF leg IK problem (hip roll + thigh pitch + calf pitch)
+ * given a desired foot position in trunk frame.
+ *
+ * This is the same algorithm used in unitree_legged_sdk's
+ * footPositionInHipFrame2JointAngle function.
+ */
+
+import { GO1_DIMENSIONS, HIP_ORIGINS, JOINT_LIMITS, type LegPrefix } from '../unitree-go1';
+
+const { thighLength: L1, calfLength: L2, thighOffset: D } = GO1_DIMENSIONS;
+
+export interface IKResult {
+  hipRoll: number;
+  thigh: number;
+  calf: number;
+}
+
+/**
+ * Solve IK for one leg.
+ *
+ * @param leg    - Which leg (FR, FL, RR, RL)
+ * @param footX  - Foot X position in trunk frame (forward)
+ * @param footY  - Foot Y position in trunk frame (left)
+ * @param footZ  - Foot Z position in trunk frame (up)
+ * @returns      - Joint angles or null if unreachable
+ */
+export function legIK(
+  leg: LegPrefix,
+  footX: number,
+  footY: number,
+  footZ: number,
+): IKResult | null {
+  const origin = HIP_ORIGINS[leg];
+  const sideSign = leg === 'FL' || leg === 'RL' ? 1 : -1;
+
+  // Transform to hip frame
+  const px = footX - origin.x;
+  const py = footY - origin.y;
+  const pz = footZ - origin.z;
+
+  // Solve hip roll from lateral geometry
+  const lateralDist = Math.sqrt(py * py + pz * pz);
+  if (lateralDist < Math.abs(D * sideSign)) return null; // unreachable
+
+  const hipRoll = Math.atan2(
+    -pz,
+    sideSign * Math.sqrt(Math.max(0, py * py + pz * pz - D * D)),
+  ) - Math.atan2(0, sideSign * D);
+
+  // Rotate into the hip-roll-aligned sagittal plane
+  const cr = Math.cos(hipRoll);
+  const sr = Math.sin(hipRoll);
+  const pzRot = py * sr + pz * cr;
+  // pzRot is the effective "downward" distance in the sagittal plane
+
+  // 2R planar IK (thigh + calf)
+  const reach = px * px + pzRot * pzRot;
+  const L1sq = L1 * L1;
+  const L2sq = L2 * L2;
+
+  const cosCalfArg = (reach - L1sq - L2sq) / (2 * L1 * L2);
+  if (Math.abs(cosCalfArg) > 1) return null; // unreachable
+
+  // "Elbow back" solution (negative calf angle, matching GO1 convention)
+  const calf = -Math.acos(clamp(cosCalfArg, -1, 1));
+
+  const thigh =
+    Math.atan2(px, -pzRot) -
+    Math.atan2(L2 * Math.sin(calf), L1 + L2 * Math.cos(calf));
+
+  // Clamp to joint limits
+  const result: IKResult = {
+    hipRoll: clamp(hipRoll, JOINT_LIMITS.hip.lower, JOINT_LIMITS.hip.upper),
+    thigh: clamp(thigh, JOINT_LIMITS.thigh.lower, JOINT_LIMITS.thigh.upper),
+    calf: clamp(calf, JOINT_LIMITS.calf.lower, JOINT_LIMITS.calf.upper),
+  };
+
+  return result;
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+/**
+ * Compute default standing foot positions (all legs touching ground).
+ * Useful as a starting point for gait planning.
+ */
+export function defaultStandingFeet(): Record<LegPrefix, [number, number, number]> {
+  const standHeight = -(L1 + L2 * 0.85); // slightly bent knees
+  return {
+    FR: [HIP_ORIGINS.FR.x, HIP_ORIGINS.FR.y - D, standHeight],
+    FL: [HIP_ORIGINS.FL.x, HIP_ORIGINS.FL.y + D, standHeight],
+    RR: [HIP_ORIGINS.RR.x, HIP_ORIGINS.RR.y - D, standHeight],
+    RL: [HIP_ORIGINS.RL.x, HIP_ORIGINS.RL.y + D, standHeight],
+  };
+}

--- a/simulator/src/lib/modules.ts
+++ b/simulator/src/lib/modules.ts
@@ -1,0 +1,239 @@
+import type { ModuleInfo } from './types';
+
+export const CATEGORY_ORDER = ['Fundamentals', 'Integration', 'Security', 'Full-Stack'] as const;
+
+export const CATEGORY_META: Record<
+  string,
+  {
+    eyebrow: string;
+    description: string;
+    accent: 'sea' | 'aqua' | 'ocean' | 'mist';
+  }
+> = {
+  Fundamentals: {
+    eyebrow: 'Phase 01',
+    description: 'Core protocols, serial basics, Move objects, and real-time transport.',
+    accent: 'sea',
+  },
+  Integration: {
+    eyebrow: 'Phase 02',
+    description: 'Connect chain events, sockets, and robot command execution into one loop.',
+    accent: 'aqua',
+  },
+  Security: {
+    eyebrow: 'Phase 03',
+    description: 'Add authentication, signed commands, and token-based access control.',
+    accent: 'ocean',
+  },
+  'Full-Stack': {
+    eyebrow: 'Phase 04',
+    description: 'Ship multiplayer and rental flows with servers, dApps, and Move contracts.',
+    accent: 'mist',
+  },
+};
+
+export const MODULES: ModuleInfo[] = [
+  {
+    id: 'R1',
+    title: 'Hello Bittle',
+    subtitle: 'Serial Basics',
+    category: 'Fundamentals',
+    time: '1-2 hours',
+    simScript: 'cd R1/hello-bittle && pnpm sim',
+    hardware: true,
+    summary: 'Learn the robot command protocol and send your first motion over a serial-style interface.',
+    artifact: 'TypeScript serial client',
+    focus: ['Protocol', 'Port discovery', 'Command timing'],
+  },
+  {
+    id: 'R2',
+    title: 'My First Move Contract',
+    subtitle: 'Blockchain Fundamentals',
+    category: 'Fundamentals',
+    time: '2-3 hours',
+    simScript: 'cd R2/move && sui move build',
+    hardware: false,
+    summary: 'Model a shared action queue on Sui and learn how on-chain state drives robot behavior later.',
+    artifact: 'Move package and CLI client',
+    focus: ['Shared objects', 'Move package build', 'Queue reads and writes'],
+  },
+  {
+    id: 'R3',
+    title: 'WebSocket Playground',
+    subtitle: 'Real-time Basics',
+    category: 'Fundamentals',
+    time: '2 hours',
+    simScript: 'cd R3/server && pnpm start',
+    hardware: false,
+    summary: 'Expose the robot through WebSocket so browsers can control it with low-latency feedback.',
+    artifact: 'WebSocket server and browser UI',
+    focus: ['Realtime messaging', 'Browser control', 'Broadcast state'],
+  },
+  {
+    id: 'R4',
+    title: 'Blockchain Robot',
+    subtitle: 'First Integration',
+    category: 'Integration',
+    time: '2-3 hours',
+    simScript: 'cd R4/processor && pnpm sim',
+    hardware: true,
+    summary: 'Bridge queued chain actions to actual robot commands and observe the digital-to-physical loop.',
+    artifact: 'Polling processor service',
+    focus: ['Queue polling', 'Command mapping', 'Processor reliability'],
+  },
+  {
+    id: 'R5',
+    title: 'Live Control',
+    subtitle: 'WebSocket + Serial',
+    category: 'Integration',
+    time: '1-2 hours',
+    simScript: 'cd R5/server && pnpm sim',
+    hardware: true,
+    summary: 'Combine sockets with robot I/O so a live control surface can drive the simulator or hardware.',
+    artifact: 'Realtime robot control server',
+    focus: ['Socket transport', 'Queue behavior', 'Latency-aware control'],
+  },
+  {
+    id: 'R6',
+    title: 'Open to the World',
+    subtitle: 'Tunneling 101',
+    category: 'Integration',
+    time: '30 min',
+    simScript: 'Uses R5 sim server',
+    hardware: false,
+    summary: 'Take your local robot endpoint public with a controlled tunnel and operational safety in mind.',
+    artifact: 'Operational tunnel scripts',
+    focus: ['Remote access', 'Tunnel setup', 'Ops workflow'],
+  },
+  {
+    id: 'R7',
+    title: 'Secure the Channel',
+    subtitle: 'Authentication',
+    category: 'Security',
+    time: '2-3 hours',
+    simScript: 'cd R7/part-a-offchain && pnpm sim',
+    hardware: true,
+    summary: 'Add cryptographic identity to robot commands so remote control can be trusted and verified.',
+    artifact: 'Authenticated command server',
+    focus: ['Ed25519', 'Challenge response', 'Command verification'],
+  },
+  {
+    id: 'R8',
+    title: 'Pay to Play',
+    subtitle: 'Tokenomics',
+    category: 'Security',
+    time: '3-4 hours',
+    simScript: 'cd R8/client && pnpm demo',
+    hardware: false,
+    summary: 'Use custom tokens and faucet logic to price robot actions and formalize access economics.',
+    artifact: 'Move token and pricing flow',
+    focus: ['Coin standard', 'Faucet rules', 'Paid robot actions'],
+  },
+  {
+    id: 'R9',
+    title: 'Multiplayer Robot',
+    subtitle: 'Shared State',
+    category: 'Full-Stack',
+    time: '3+ hours',
+    simScript: 'cd R9/server && pnpm start',
+    hardware: false,
+    summary: 'Build a fair multiplayer robot queue with on-chain ordering, server state, and a wallet dApp.',
+    artifact: 'Move queue, server, and dApp',
+    focus: ['Fair scheduling', 'Shared state', 'Wallet-connected UI'],
+  },
+  {
+    id: 'R10',
+    title: 'Robot Rental Platform',
+    subtitle: 'Capstone',
+    category: 'Full-Stack',
+    time: '4+ hours',
+    simScript: 'SIMULATE_ROBOT=true cd R10/server && pnpm start',
+    hardware: true,
+    summary: 'Combine registry, rental sessions, signed commands, and token settlement into a complete platform.',
+    artifact: 'Full rental stack',
+    focus: ['Session escrow', 'Signed control', 'Production architecture'],
+  },
+];
+
+/** Key concepts taught in each module */
+export const MODULE_CONCEPTS: Record<string, string[]> = {
+  R1: [
+    'Serial communication (UART)',
+    'Bittle command protocol',
+    'Buffer parsing',
+    'Hardware abstraction',
+  ],
+  R2: [
+    'Move language basics',
+    'Sui object model',
+    'Package publishing',
+    'On-chain state',
+  ],
+  R3: [
+    'WebSocket protocol',
+    'Real-time bidirectional communication',
+    'Event-driven architecture',
+    'Connection lifecycle',
+  ],
+  R4: [
+    'Blockchain event subscription',
+    'Transaction processing',
+    'Serial command bridge',
+    'On-chain to off-chain flow',
+  ],
+  R5: [
+    'WebSocket server',
+    'Serial port forwarding',
+    'Live robot control UI',
+    'State synchronization',
+  ],
+  R6: [
+    'ngrok tunneling',
+    'Public URL exposure',
+    'Network address translation',
+    'Remote access patterns',
+  ],
+  R7: [
+    'Ed25519 signatures',
+    'Challenge-response auth',
+    'Sui cryptography',
+    'Secure command channels',
+  ],
+  R8: [
+    'SUI token payments',
+    'Pay-per-command model',
+    'Transaction verification',
+    'Token economics',
+  ],
+  R9: [
+    'Shared object state',
+    'Multi-user coordination',
+    'Consensus and ordering',
+    'Real-time multiplayer',
+  ],
+  R10: [
+    'Full platform architecture',
+    'Rental smart contracts',
+    'Session management',
+    'Production deployment',
+  ],
+};
+
+export function getModuleOrder(id: string): number {
+  const match = id.match(/^R(\d+)$/);
+  return match ? Number.parseInt(match[1], 10) : Number.MAX_SAFE_INTEGER;
+}
+
+export function getOrderedModules<T extends { id: string }>(modules: readonly T[]): T[] {
+  return [...modules].sort((left, right) => getModuleOrder(left.id) - getModuleOrder(right.id));
+}
+
+export function getCurriculumPhases<T extends { id: string; category: string }>(modules: readonly T[]) {
+  const orderedModules = getOrderedModules(modules);
+
+  return CATEGORY_ORDER.map((category) => ({
+    category,
+    meta: CATEGORY_META[category],
+    modules: orderedModules.filter((module) => module.category === category),
+  }));
+}

--- a/simulator/src/lib/physics/rapier-world.ts
+++ b/simulator/src/lib/physics/rapier-world.ts
@@ -1,0 +1,111 @@
+/**
+ * Rapier3D Physics World
+ *
+ * Manages the WASM physics engine lifecycle:
+ * - Async initialization (WASM loading)
+ * - World creation with gravity
+ * - Ground plane
+ * - Debug rendering to Three.js LineSegments
+ */
+
+import * as THREE from 'three';
+
+// Rapier is loaded dynamically to avoid SSR issues
+let RAPIER: typeof import('@dimforge/rapier3d-compat') | null = null;
+
+export async function initRapier() {
+  if (RAPIER) return RAPIER;
+  const rapier = await import('@dimforge/rapier3d-compat');
+  await rapier.init();
+  RAPIER = rapier;
+  return rapier;
+}
+
+export function getRapier() {
+  if (!RAPIER) throw new Error('Rapier not initialized. Call initRapier() first.');
+  return RAPIER;
+}
+
+export interface PhysicsWorld {
+  world: InstanceType<typeof import('@dimforge/rapier3d-compat').World>;
+  groundCollider: unknown;
+  debugMesh: THREE.LineSegments;
+  step: (dt?: number) => void;
+  updateDebugMesh: () => void;
+  dispose: () => void;
+}
+
+export function createPhysicsWorld(): PhysicsWorld {
+  const rapier = getRapier();
+  const world = new rapier.World({ x: 0, y: -9.81, z: 0 });
+
+  // Ground plane at y = 0
+  const groundDesc = rapier.ColliderDesc.cuboid(50, 0.01, 50)
+    .setTranslation(0, -0.01, 0)
+    .setFriction(1.0)
+    .setRestitution(0.0);
+  const groundCollider = world.createCollider(groundDesc);
+
+  // Debug render mesh
+  const debugGeom = new THREE.BufferGeometry();
+  const debugMat = new THREE.LineBasicMaterial({ color: 0x00ff00, vertexColors: true });
+  const debugMesh = new THREE.LineSegments(debugGeom, debugMat);
+  debugMesh.visible = false;
+  debugMesh.frustumCulled = false;
+
+  function step(dt = 1 / 60) {
+    world.timestep = dt;
+    world.step();
+  }
+
+  function updateDebugMesh() {
+    const buffers = world.debugRender();
+    debugGeom.setAttribute('position', new THREE.BufferAttribute(buffers.vertices, 3));
+    debugGeom.setAttribute('color', new THREE.BufferAttribute(buffers.colors, 4));
+  }
+
+  function dispose() {
+    world.free();
+    debugGeom.dispose();
+    debugMat.dispose();
+  }
+
+  return { world, groundCollider, debugMesh, step, updateDebugMesh, dispose };
+}
+
+/**
+ * Load a GLB mesh as static trimesh colliders in the physics world.
+ */
+export function addEnvironmentMesh(
+  world: PhysicsWorld['world'],
+  mesh: THREE.Mesh,
+): unknown[] {
+  const rapier = getRapier();
+  const colliders: unknown[] = [];
+
+  const geom = mesh.geometry;
+  if (!geom.index) return colliders;
+
+  // Get world-space vertices
+  const posAttr = geom.attributes.position;
+  const vertices = new Float32Array(posAttr.count * 3);
+  const tempVec = new THREE.Vector3();
+  mesh.updateMatrixWorld(true);
+
+  for (let i = 0; i < posAttr.count; i++) {
+    tempVec.fromBufferAttribute(posAttr, i);
+    tempVec.applyMatrix4(mesh.matrixWorld);
+    vertices[i * 3] = tempVec.x;
+    vertices[i * 3 + 1] = tempVec.y;
+    vertices[i * 3 + 2] = tempVec.z;
+  }
+
+  const indices = new Uint32Array(geom.index.array);
+
+  const desc = rapier.ColliderDesc.trimesh(vertices, indices)
+    .setFriction(0.8)
+    .setRestitution(0.1);
+
+  colliders.push(world.createCollider(desc));
+  return colliders;
+}

--- a/simulator/src/lib/robot.ts
+++ b/simulator/src/lib/robot.ts
@@ -1,0 +1,479 @@
+// Virtual Bittle Robot — State Machine
+// Simulates the Petoi Bittle X command protocol
+
+export interface JointAngles {
+  headPitch: number;
+  headYaw: number;
+  tailWag: number;
+  frontLeftHip: number;
+  frontLeftKnee: number;
+  frontRightHip: number;
+  frontRightKnee: number;
+  backLeftHip: number;
+  backLeftKnee: number;
+  backRightHip: number;
+  backRightKnee: number;
+}
+
+export interface RobotState {
+  action: string;
+  actionLabel: string;
+  joints: JointAngles;
+  bodyHeight: number;
+  bodyPitch: number;
+  bodyRoll: number;
+  moving: boolean;
+  walkCycle: number;
+  mood: "happy" | "neutral" | "sleepy" | "excited";
+  battery: number;
+  uptime: number;
+  commandsExecuted: number;
+}
+
+export interface RobotEvent {
+  type: "state_change" | "command_ack" | "error" | "info";
+  action?: string;
+  message: string;
+  timestamp: number;
+}
+
+type StateListener = (state: RobotState, event: RobotEvent) => void;
+
+// Default standing pose
+const STAND_JOINTS: JointAngles = {
+  headPitch: 0,
+  headYaw: 0,
+  tailWag: 0,
+  frontLeftHip: 0,
+  frontLeftKnee: 0,
+  frontRightHip: 0,
+  frontRightKnee: 0,
+  backLeftHip: 0,
+  backLeftKnee: 0,
+  backRightHip: 0,
+  backRightKnee: 0,
+};
+
+// Alias map: alternate command names → canonical Bittle action codes
+// Supports R3's command set, R1's command names, and common shortcuts
+const ALIASES: Record<string, string> = {
+  // R3 WebSocket protocol commands
+  forward: "wkF",
+  backward: "bk",
+  left: "wkL",
+  right: "wkR",
+  stand: "balance",
+  lie: "rest",
+  wave: "hi",
+  sleep: "rest",
+  wake: "balance",
+  reset: "balance",
+  // R1 command names (camelCase)
+  walkForward: "wkF",
+  walkBackward: "bk",
+  walkLeft: "wkL",
+  walkRight: "wkR",
+  trotForward: "trF",
+  trotLeft: "trL",
+  trotRight: "trR",
+  pushUp: "pu",
+  playDead: "pd",
+  stretch: "str",
+  backFlip: "bf",
+  calibrate: "balance",
+  zero: "balance",
+  standUp: "up",
+  // R5/R7/R10 common names
+  sitDown: "sit",
+  standUp2: "up",
+  jump: "jmp",
+  trot: "trF",
+  pushup: "pu",
+  playdead: "pd",
+  standup: "up",
+  // Short aliases
+  walk: "wkF",
+  back: "bk",
+  hello: "hi",
+  // Underscore variants (from blockchain action names)
+  walk_forward: "wkF",
+  walk_backward: "bk",
+  walk_left: "wkL",
+  walk_right: "wkR",
+  trot_forward: "trF",
+  push_up: "pu",
+  play_dead: "pd",
+  stand_up: "up",
+  back_flip: "bf",
+};
+
+// Command → pose definitions
+const POSES: Record<
+  string,
+  {
+    label: string;
+    joints: Partial<JointAngles>;
+    bodyHeight?: number;
+    bodyPitch?: number;
+    bodyRoll?: number;
+    mood?: RobotState["mood"];
+    duration: number;
+    moving?: boolean;
+  }
+> = {
+  sit: {
+    label: "Sitting",
+    joints: {
+      backLeftHip: -60,
+      backLeftKnee: 90,
+      backRightHip: -60,
+      backRightKnee: 90,
+      frontLeftHip: 10,
+      frontLeftKnee: -5,
+      frontRightHip: 10,
+      frontRightKnee: -5,
+    },
+    bodyHeight: -0.3,
+    bodyPitch: -15,
+    mood: "neutral",
+    duration: 2000,
+  },
+  balance: {
+    label: "Standing (balanced)",
+    joints: { ...STAND_JOINTS },
+    bodyHeight: 0,
+    bodyPitch: 0,
+    mood: "neutral",
+    duration: 2000,
+  },
+  up: {
+    label: "Standing tall",
+    joints: {
+      frontLeftKnee: -15,
+      frontRightKnee: -15,
+      backLeftKnee: -15,
+      backRightKnee: -15,
+    },
+    bodyHeight: 0.15,
+    mood: "happy",
+    duration: 2000,
+  },
+  rest: {
+    label: "Resting",
+    joints: {
+      frontLeftHip: -45,
+      frontLeftKnee: 90,
+      frontRightHip: -45,
+      frontRightKnee: 90,
+      backLeftHip: -45,
+      backLeftKnee: 90,
+      backRightHip: -45,
+      backRightKnee: 90,
+    },
+    bodyHeight: -0.55,
+    bodyPitch: 0,
+    mood: "sleepy",
+    duration: 3000,
+  },
+  hi: {
+    label: "Waving hello!",
+    joints: {
+      frontRightHip: -80,
+      frontRightKnee: -40,
+      frontLeftHip: 10,
+      frontLeftKnee: 5,
+      backLeftHip: -10,
+      backLeftKnee: 15,
+      backRightHip: -10,
+      backRightKnee: 15,
+    },
+    bodyPitch: -8,
+    bodyRoll: 8,
+    mood: "happy",
+    duration: 3000,
+  },
+  wkF: {
+    label: "Walking forward",
+    joints: { ...STAND_JOINTS },
+    mood: "happy",
+    duration: 4000,
+    moving: true,
+  },
+  bk: {
+    label: "Walking backward",
+    joints: { ...STAND_JOINTS },
+    mood: "neutral",
+    duration: 4000,
+    moving: true,
+  },
+  trF: {
+    label: "Trotting forward",
+    joints: { ...STAND_JOINTS },
+    mood: "excited",
+    duration: 3000,
+    moving: true,
+  },
+  jmp: {
+    label: "Jumping!",
+    joints: {
+      frontLeftKnee: -30,
+      frontRightKnee: -30,
+      backLeftKnee: -30,
+      backRightKnee: -30,
+    },
+    bodyHeight: 0.4,
+    mood: "excited",
+    duration: 2000,
+  },
+  pu: {
+    label: "Doing a push-up",
+    joints: {
+      frontLeftHip: -30,
+      frontLeftKnee: 50,
+      frontRightHip: -30,
+      frontRightKnee: 50,
+      backLeftHip: 5,
+      backLeftKnee: -10,
+      backRightHip: 5,
+      backRightKnee: -10,
+    },
+    bodyPitch: 20,
+    bodyHeight: -0.2,
+    mood: "excited",
+    duration: 5000,
+  },
+  pd: {
+    label: "Playing dead",
+    joints: {
+      frontLeftHip: 30,
+      frontLeftKnee: 60,
+      frontRightHip: -60,
+      frontRightKnee: 60,
+      backLeftHip: 30,
+      backLeftKnee: 60,
+      backRightHip: -60,
+      backRightKnee: 60,
+    },
+    bodyHeight: -0.6,
+    bodyRoll: 90,
+    mood: "sleepy",
+    duration: 3000,
+  },
+  str: {
+    label: "Stretching",
+    joints: {
+      frontLeftHip: 30,
+      frontLeftKnee: -20,
+      frontRightHip: 30,
+      frontRightKnee: -20,
+      backLeftHip: -40,
+      backLeftKnee: 30,
+      backRightHip: -40,
+      backRightKnee: 30,
+    },
+    bodyPitch: 15,
+    bodyHeight: -0.15,
+    mood: "happy",
+    duration: 3000,
+  },
+  // Additional movement commands
+  wkL: {
+    label: "Walking left",
+    joints: { ...STAND_JOINTS },
+    bodyRoll: -5,
+    mood: "neutral",
+    duration: 4000,
+    moving: true,
+  },
+  wkR: {
+    label: "Walking right",
+    joints: { ...STAND_JOINTS },
+    bodyRoll: 5,
+    mood: "neutral",
+    duration: 4000,
+    moving: true,
+  },
+  trL: {
+    label: "Trotting left",
+    joints: { ...STAND_JOINTS },
+    bodyRoll: -5,
+    mood: "excited",
+    duration: 3000,
+    moving: true,
+  },
+  trR: {
+    label: "Trotting right",
+    joints: { ...STAND_JOINTS },
+    bodyRoll: 5,
+    mood: "excited",
+    duration: 3000,
+    moving: true,
+  },
+  bf: {
+    label: "Back flip!",
+    joints: {
+      frontLeftKnee: -40,
+      frontRightKnee: -40,
+      backLeftKnee: -40,
+      backRightKnee: -40,
+    },
+    bodyHeight: 0.5,
+    bodyPitch: -30,
+    mood: "excited",
+    duration: 3000,
+  },
+};
+
+export class VirtualBittle {
+  state: RobotState;
+  private listeners: StateListener[] = [];
+  private actionTimer: ReturnType<typeof setTimeout> | null = null;
+  private startTime: number;
+
+  constructor() {
+    this.startTime = Date.now();
+    this.state = {
+      action: "idle",
+      actionLabel: "Idle",
+      joints: { ...STAND_JOINTS },
+      bodyHeight: 0,
+      bodyPitch: 0,
+      bodyRoll: 0,
+      moving: false,
+      walkCycle: 0,
+      mood: "neutral",
+      battery: 100,
+      uptime: 0,
+      commandsExecuted: 0,
+    };
+  }
+
+  onStateChange(listener: StateListener) {
+    this.listeners.push(listener);
+  }
+
+  removeListener(listener: StateListener) {
+    this.listeners = this.listeners.filter((l) => l !== listener);
+  }
+
+  private emit(event: RobotEvent) {
+    for (const listener of this.listeners) {
+      listener(this.state, event);
+    }
+  }
+
+  /** Resolve an action name through the alias table */
+  private resolveAction(name: string): string {
+    // Direct match first
+    if (POSES[name]) return name;
+    // Check aliases
+    const aliased = ALIASES[name];
+    if (aliased && POSES[aliased]) return aliased;
+    return name; // Return as-is (will fail in executeAction with helpful error)
+  }
+
+  /** Parse a raw serial command (e.g., "ksit\n") and execute it */
+  processCommand(raw: string): string {
+    const cmd = raw.trim();
+
+    // Bittle commands start with 'k' prefix for skills
+    if (cmd.startsWith("k")) {
+      const action = cmd.slice(1); // Strip 'k' prefix
+      return this.executeAction(action);
+    }
+
+    // Also accept bare action names and aliases (for WebSocket/R3 compat)
+    return this.executeAction(cmd);
+  }
+
+  /** Execute a named action */
+  executeAction(action: string): string {
+    // Resolve aliases
+    action = this.resolveAction(action);
+    const pose = POSES[action];
+
+    if (!pose) {
+      const msg = `Unknown action: "${action}" (valid: ${Object.keys(POSES).join(", ")})`;
+      this.emit({
+        type: "error",
+        action,
+        message: msg,
+        timestamp: Date.now(),
+      });
+      return msg;
+    }
+
+    // Cancel any in-progress action
+    if (this.actionTimer) {
+      clearTimeout(this.actionTimer);
+    }
+
+    // Apply the pose
+    this.state.action = action;
+    this.state.actionLabel = pose.label;
+    this.state.moving = pose.moving || false;
+    this.state.mood = pose.mood || "neutral";
+    this.state.commandsExecuted++;
+    this.state.uptime = Math.floor((Date.now() - this.startTime) / 1000);
+
+    // Drain battery slightly
+    this.state.battery = Math.max(0, this.state.battery - 0.5);
+
+    // Merge joint angles
+    this.state.joints = {
+      ...STAND_JOINTS,
+      ...(pose.joints as JointAngles),
+    };
+    if (pose.bodyHeight !== undefined) this.state.bodyHeight = pose.bodyHeight;
+    if (pose.bodyPitch !== undefined) this.state.bodyPitch = pose.bodyPitch;
+    if (pose.bodyRoll !== undefined) this.state.bodyRoll = pose.bodyRoll;
+
+    const msg = `[OK] ${pose.label}`;
+    this.emit({
+      type: "state_change",
+      action,
+      message: msg,
+      timestamp: Date.now(),
+    });
+
+    // After duration, return to idle standing
+    this.actionTimer = setTimeout(() => {
+      this.state.action = "idle";
+      this.state.actionLabel = "Idle";
+      this.state.moving = false;
+      this.state.joints = { ...STAND_JOINTS };
+      this.state.bodyHeight = 0;
+      this.state.bodyPitch = 0;
+      this.state.bodyRoll = 0;
+      this.state.mood = "neutral";
+
+      this.emit({
+        type: "info",
+        message: "Action complete, returned to idle",
+        timestamp: Date.now(),
+      });
+    }, pose.duration);
+
+    return msg;
+  }
+
+  getState(): RobotState {
+    this.state.uptime = Math.floor((Date.now() - this.startTime) / 1000);
+    return { ...this.state };
+  }
+
+  /** List all available commands */
+  static getCommands(): Array<{
+    code: string;
+    serial: string;
+    label: string;
+    duration: number;
+  }> {
+    return Object.entries(POSES).map(([code, pose]) => ({
+      code,
+      serial: `k${code}`,
+      label: pose.label,
+      duration: pose.duration,
+    }));
+  }
+}

--- a/simulator/src/lib/sui-dapp-kit.ts
+++ b/simulator/src/lib/sui-dapp-kit.ts
@@ -32,6 +32,15 @@ export function getSuiDAppKit() {
   return suiDAppKitSingleton;
 }
 
+export const SUI_CONTRACT = {
+  packageId: process.env.NEXT_PUBLIC_SUI_PACKAGE_ID ?? '',
+  queueId: process.env.NEXT_PUBLIC_SUI_QUEUE_ID ?? '',
+} as const;
+
+export function isOnChainConfigured(): boolean {
+  return SUI_CONTRACT.packageId.length > 0 && SUI_CONTRACT.queueId.length > 0;
+}
+
 declare module '@mysten/dapp-kit-react' {
   interface Register {
     dAppKit: ReturnType<typeof getSuiDAppKit>;

--- a/simulator/src/lib/sui-dapp-kit.ts
+++ b/simulator/src/lib/sui-dapp-kit.ts
@@ -37,6 +37,12 @@ export const SUI_CONTRACT = {
   queueId: process.env.NEXT_PUBLIC_SUI_QUEUE_ID ?? '0x83ba18609f73b99518b7aaa13ce4a17293c4d18c4e2bab38ce59c7dc0fef355c',
 } as const;
 
+export const COOKIE_CONTRACT = {
+  packageId: '0x1a0761c44b99b65d9d4220d7be34c9042954126699c4f4ce7339d9ac90a11821',
+  faucetId: '0xcdefdd53f71d25b76020aa5420dfc4950228f3c8f87ecc2f38eff19444d405f0',
+  coinType: '0x1a0761c44b99b65d9d4220d7be34c9042954126699c4f4ce7339d9ac90a11821::cookie::COOKIE',
+} as const;
+
 export function isOnChainConfigured(): boolean {
   return SUI_CONTRACT.packageId.length > 0 && SUI_CONTRACT.queueId.length > 0;
 }

--- a/simulator/src/lib/sui-dapp-kit.ts
+++ b/simulator/src/lib/sui-dapp-kit.ts
@@ -33,8 +33,8 @@ export function getSuiDAppKit() {
 }
 
 export const SUI_CONTRACT = {
-  packageId: process.env.NEXT_PUBLIC_SUI_PACKAGE_ID ?? '',
-  queueId: process.env.NEXT_PUBLIC_SUI_QUEUE_ID ?? '',
+  packageId: process.env.NEXT_PUBLIC_SUI_PACKAGE_ID ?? '0x27a3292a055a7904753a8c741579d9cdebc17010c8b65d3d1f00da43047962b7',
+  queueId: process.env.NEXT_PUBLIC_SUI_QUEUE_ID ?? '0x83ba18609f73b99518b7aaa13ce4a17293c4d18c4e2bab38ce59c7dc0fef355c',
 } as const;
 
 export function isOnChainConfigured(): boolean {

--- a/simulator/src/lib/sui-dapp-kit.ts
+++ b/simulator/src/lib/sui-dapp-kit.ts
@@ -1,0 +1,39 @@
+import { createDAppKit } from '@mysten/dapp-kit-core';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const GRPC_URLS = {
+  testnet: 'https://fullnode.testnet.sui.io:443',
+} as const;
+
+function createSuiDAppKit() {
+  return createDAppKit({
+    defaultNetwork: 'testnet',
+    networks: ['testnet'] as const,
+    createClient(network) {
+      return new SuiGrpcClient({
+        network,
+        baseUrl: GRPC_URLS[network],
+      });
+    },
+  });
+}
+
+let suiDAppKitSingleton: ReturnType<typeof createSuiDAppKit> | null = null;
+
+export function getSuiDAppKit() {
+  if (typeof window === 'undefined') {
+    throw new Error('Sui dApp Kit must be created in the browser');
+  }
+
+  if (!suiDAppKitSingleton) {
+    suiDAppKitSingleton = createSuiDAppKit();
+  }
+
+  return suiDAppKitSingleton;
+}
+
+declare module '@mysten/dapp-kit-react' {
+  interface Register {
+    dAppKit: ReturnType<typeof getSuiDAppKit>;
+  }
+}

--- a/simulator/src/lib/types.ts
+++ b/simulator/src/lib/types.ts
@@ -1,0 +1,56 @@
+export interface JointAngles {
+  headPitch: number;
+  headYaw: number;
+  tailWag: number;
+  frontLeftHip: number;
+  frontLeftKnee: number;
+  frontRightHip: number;
+  frontRightKnee: number;
+  backLeftHip: number;
+  backLeftKnee: number;
+  backRightHip: number;
+  backRightKnee: number;
+}
+
+export interface RobotState {
+  action: string;
+  actionLabel: string;
+  joints: JointAngles;
+  bodyHeight: number;
+  bodyPitch: number;
+  bodyRoll: number;
+  moving: boolean;
+  walkCycle: number;
+  mood: 'happy' | 'neutral' | 'sleepy' | 'excited';
+  battery: number;
+  uptime: number;
+  commandsExecuted: number;
+}
+
+export interface RobotEvent {
+  type: 'state_change' | 'command_ack' | 'error' | 'info';
+  action?: string;
+  message: string;
+  timestamp: number;
+}
+
+export interface ModuleInfo {
+  id: string;
+  title: string;
+  subtitle: string;
+  category: string;
+  time: string;
+  simScript: string;
+  hardware: boolean;
+  summary: string;
+  artifact: string;
+  focus: string[];
+  readme?: string;
+}
+
+export interface Command {
+  code: string;
+  serial: string;
+  label: string;
+  duration: number;
+}

--- a/simulator/src/lib/unitree-go1.ts
+++ b/simulator/src/lib/unitree-go1.ts
@@ -1,0 +1,180 @@
+/**
+ * Unitree GO1 Robot Configuration
+ *
+ * Kinematic parameters extracted from the official unitree_ros SDK:
+ * https://github.com/unitreerobotics/unitree_ros
+ *
+ * Source files:
+ *   robots/go1_description/xacro/const.xacro  — dimensions, joint limits, inertias
+ *   robots/go1_description/xacro/robot.xacro   — assembly (trunk + 4 legs + sensors)
+ *   robots/go1_description/xacro/leg.xacro      — parametric leg macro
+ *   robots/go1_description/config/robot_control.yaml — PID gains
+ *
+ * Coordinate frame convention (ROS REP-103):
+ *   X = forward, Y = left, Z = up
+ *
+ * The GO1 has 12 actuated revolute joints (3 per leg):
+ *   hip_joint   — abduction/adduction (roll around X-axis)
+ *   thigh_joint — flexion/extension (pitch around Y-axis)
+ *   calf_joint  — knee flexion (pitch around Y-axis)
+ */
+
+// ── Joint limits (radians) from const.xacro ──────────────────
+
+export const JOINT_LIMITS = {
+  hip:   { lower: -0.863, upper: 0.863 },   // ±49.4°
+  thigh: { lower: -0.686, upper: 4.501 },   // -39.3° to 257.8°
+  calf:  { lower: -2.818, upper: -0.888 },  // -161.5° to -50.9°
+} as const;
+
+export const JOINT_EFFORT = {
+  hip:   23.7,   // Nm
+  thigh: 23.7,   // Nm
+  calf:  35.55,  // Nm
+} as const;
+
+export const JOINT_VELOCITY = {
+  hip:   30.1,   // rad/s
+  thigh: 30.1,   // rad/s
+  calf:  20.06,  // rad/s
+} as const;
+
+// ── Link dimensions (meters) from const.xacro ───────────────
+
+export const GO1_DIMENSIONS = {
+  trunkLength:  0.3762,
+  trunkWidth:   0.0935,
+  trunkHeight:  0.114,
+  hipOffset:    0.08,    // lateral offset of hip housing
+  thighOffset:  0.08,    // lateral offset from hip joint to thigh joint
+  thighLength:  0.213,   // upper leg (hip-to-knee)
+  calfLength:   0.213,   // lower leg (knee-to-foot)
+  footRadius:   0.02,
+  legOffsetX:   0.1881,  // longitudinal offset of hip from trunk center
+  legOffsetY:   0.04675, // lateral offset of hip from trunk center
+} as const;
+
+export const GO1_MASS = {
+  trunk: 5.204,
+  hipRotorInertia:   0.891,
+  hipLink:           0.696,
+  thighRotorInertia: 0.891,
+  thighLink:         1.013,
+  calfLink:          0.166,
+  totalApprox:       12.84, // kg
+} as const;
+
+// ── URDF joint names ─────────────────────────────────────────
+
+export type LegPrefix = 'FR' | 'FL' | 'RR' | 'RL';
+
+export const LEG_PREFIXES: LegPrefix[] = ['FR', 'FL', 'RR', 'RL'];
+
+export const LEG_LABELS: Record<LegPrefix, string> = {
+  FR: 'Front Right',
+  FL: 'Front Left',
+  RR: 'Rear Right',
+  RL: 'Rear Left',
+};
+
+/** Returns the 3 URDF joint names for a given leg */
+export function getJointNames(leg: LegPrefix) {
+  return {
+    hip:   `${leg}_hip_joint`,
+    thigh: `${leg}_thigh_joint`,
+    calf:  `${leg}_calf_joint`,
+  } as const;
+}
+
+/** Returns the URDF link names for a given leg */
+export function getLinkNames(leg: LegPrefix) {
+  return {
+    hip:   `${leg}_hip`,
+    thigh: `${leg}_thigh`,
+    calf:  `${leg}_calf`,
+    foot:  `${leg}_foot`,
+  } as const;
+}
+
+/** All 12 actuated joint names in URDF order */
+export const ALL_JOINT_NAMES = LEG_PREFIXES.flatMap((leg) => {
+  const names = getJointNames(leg);
+  return [names.hip, names.thigh, names.calf];
+});
+
+// ── Joint axis definitions (from URDF) ───────────────────────
+
+export const JOINT_AXES = {
+  hip:   { x: 1, y: 0, z: 0 },  // roll around X
+  thigh: { x: 0, y: 1, z: 0 },  // pitch around Y
+  calf:  { x: 0, y: 1, z: 0 },  // pitch around Y
+} as const;
+
+// ── Hip joint origins from trunk center ──────────────────────
+
+export const HIP_ORIGINS: Record<LegPrefix, { x: number; y: number; z: number }> = {
+  FR: { x:  0.1881, y: -0.04675, z: 0 },
+  FL: { x:  0.1881, y:  0.04675, z: 0 },
+  RR: { x: -0.1881, y: -0.04675, z: 0 },
+  RL: { x: -0.1881, y:  0.04675, z: 0 },
+};
+
+// ── Controller PID gains (from robot_control.yaml) ───────────
+
+export const PID_GAINS = {
+  hip:   { p: 100, i: 0, d: 5 },
+  thigh: { p: 300, i: 0, d: 8 },
+  calf:  { p: 300, i: 0, d: 8 },
+} as const;
+
+// ── Sensor configuration ─────────────────────────────────────
+
+export const CAMERAS = [
+  { name: 'face',     position: { x: 0.2785,  y: 0.0125,  z: 0.0167 } },
+  { name: 'chin',     position: { x: 0.2522,  y: 0.0125,  z: -0.0436 } },
+  { name: 'left',     position: { x: -0.066,  y: 0.082,   z: -0.0176 } },
+  { name: 'right',    position: { x: -0.041,  y: -0.082,  z: -0.0176 } },
+  { name: 'rearDown', position: { x: -0.0825, y: 0.0125,  z: -0.04365 } },
+] as const;
+
+export const ULTRASOUND_SENSORS = [
+  { name: 'left',  position: { x: -0.0535, y: 0.0826,  z: 0.00868 } },
+  { name: 'right', position: { x: -0.0535, y: -0.0826, z: 0.00868 } },
+  { name: 'face',  position: { x: 0.2747,  y: 0.0,     z: -0.0088 } },
+] as const;
+
+export const IMU_POSITION = { x: -0.01592, y: -0.06659, z: -0.00617 } as const;
+
+// ── Mapping: simulator joint names → URDF joint names ────────
+// Our simulator uses frontLeftHip/frontLeftKnee naming;
+// the URDF uses FL_hip_joint/FL_thigh_joint/FL_calf_joint.
+// The simulator currently lacks hip roll joints; thigh = hip, knee = calf.
+
+export const SIMULATOR_TO_URDF: Record<string, string> = {
+  frontLeftHip:    'FL_thigh_joint',
+  frontLeftKnee:   'FL_calf_joint',
+  frontRightHip:   'FR_thigh_joint',
+  frontRightKnee:  'FR_calf_joint',
+  backLeftHip:     'RL_thigh_joint',
+  backLeftKnee:    'RL_calf_joint',
+  backRightHip:    'RR_thigh_joint',
+  backRightKnee:   'RR_calf_joint',
+};
+
+export const URDF_TO_SIMULATOR: Record<string, string> = Object.fromEntries(
+  Object.entries(SIMULATOR_TO_URDF).map(([k, v]) => [v, k]),
+);
+
+// ── Link hierarchy (for reference/visualization) ─────────────
+
+export const LINK_HIERARCHY = `
+base (root)
+  └── trunk  (floating_base, fixed)
+        ├── imu_link
+        ├── FR_hip → FR_thigh → FR_calf → FR_foot
+        ├── FL_hip → FL_thigh → FL_calf → FL_foot
+        ├── RR_hip → RR_thigh → RR_calf → RR_foot
+        ├── RL_hip → RL_thigh → RL_calf → RL_foot
+        ├── camera_face, camera_chin, camera_left, camera_right, camera_rearDown
+        └── ultraSound_left, ultraSound_right, ultraSound_face
+` as const;

--- a/simulator/tailwind.config.cjs
+++ b/simulator/tailwind.config.cjs
@@ -1,0 +1,17 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/hooks/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+        mono: ['"JetBrains Mono"', 'ui-monospace', 'monospace'],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/simulator/tsconfig.json
+++ b/simulator/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "server.ts"]
+}

--- a/simulator/virtual-serial.ts
+++ b/simulator/virtual-serial.ts
@@ -1,0 +1,87 @@
+/**
+ * VirtualSerialPort — Drop-in replacement for the `serialport` library.
+ *
+ * Instead of talking to a physical USB device, this connects to the
+ * SuiBotics simulator via WebSocket, letting you run all R-module code
+ * without any hardware.
+ *
+ * Usage (in any R module):
+ *
+ *   // Replace:
+ *   // import { SerialPort } from "serialport";
+ *   // const port = new SerialPort({ path: "/dev/ttyACM0", baudRate: 115200 });
+ *
+ *   // With:
+ *   import { VirtualSerialPort as SerialPort } from "../simulator/virtual-serial";
+ *   const port = new SerialPort({ simulatorUrl: "ws://localhost:3000/serial" });
+ */
+
+import WebSocket from "ws";
+import { EventEmitter } from "events";
+
+interface VirtualSerialOptions {
+  /** WebSocket URL of the simulator's serial endpoint */
+  simulatorUrl?: string;
+  /** Ignored — included for API compat with serialport */
+  path?: string;
+  /** Ignored — included for API compat with serialport */
+  baudRate?: number;
+}
+
+export class VirtualSerialPort extends EventEmitter {
+  private ws: WebSocket;
+  private url: string;
+  isOpen = false;
+
+  constructor(options: VirtualSerialOptions = {}) {
+    super();
+    this.url = options.simulatorUrl || "ws://localhost:3000/serial";
+
+    this.ws = new WebSocket(this.url);
+
+    this.ws.on("open", () => {
+      this.isOpen = true;
+      this.emit("open");
+    });
+
+    this.ws.on("message", (data: WebSocket.Data) => {
+      const buf = Buffer.from(data.toString());
+      this.emit("data", buf);
+    });
+
+    this.ws.on("error", (err: Error) => {
+      this.emit("error", err);
+    });
+
+    this.ws.on("close", () => {
+      this.isOpen = false;
+      this.emit("close");
+    });
+  }
+
+  write(data: string | Buffer, callback?: (err?: Error | null) => void): boolean {
+    if (!this.isOpen) {
+      const err = new Error("Port is not open");
+      if (callback) callback(err);
+      return false;
+    }
+
+    try {
+      this.ws.send(data.toString());
+      if (callback) callback(null);
+      return true;
+    } catch (err) {
+      if (callback) callback(err as Error);
+      return false;
+    }
+  }
+
+  close(callback?: (err?: Error | null) => void): void {
+    this.ws.close();
+    this.isOpen = false;
+    if (callback) callback(null);
+  }
+}
+
+// Also export as SerialPort for easier drop-in replacement
+export { VirtualSerialPort as SerialPort };


### PR DESCRIPTION
## Summary

Adds a hardware-free 3D robot simulator so learners can complete the entire R1-R10 robotics track without a physical Petoi Bittle X robot. Every robot action is a real Sui testnet transaction signed by the user's wallet.

### Simulator core

- **Next.js playground** at `simulator/` — Three.js virtual Unitree GO1 with animated poses and walk cycles
- **TCP serial bridge** on port 8375 — R modules connect via a zero-dependency `VirtualSerialPort` adapter
- **Simulation entry points** — `src/sim.ts` files and `pnpm sim` scripts added to R1, R4, R5, and R7
- **Module browser** — renders each module's README with architecture diagrams and simulator instructions
- **Sui.io design system** — dark navbar, dotted grid background, TWK Everett font, clean flat cards

### On-chain actions (wallet-gated)

The robot requires a connected Sui wallet. Without one, the playground shows a connect prompt. With a wallet connected, every action follows this flow:

1. User clicks a button or presses a keyboard shortcut
2. A PTB calling `robot_queue::add_action` is built and sent to the wallet for signing
3. The wallet prompts the user to approve the transaction
4. Once the transaction confirms on Sui testnet, the robot animates
5. A success toast appears with the action name

If the transaction fails or is rejected, the robot does not move and an error toast is shown.

### Deployed contract (testnet)

Uses the R2 `action_queue::robot_queue` contract:

| | Address |
|---|---|
| Package | `0x27a3292a055a7904753a8c741579d9cdebc17010c8b65d3d1f00da43047962b7` |
| ActionQueue | `0x83ba18609f73b99518b7aaa13ce4a17293c4d18c4e2bab38ce59c7dc0fef355c` |

### Wallet integration

- Custom connect wallet modal (full-view centered dialog via React portal, z-index 99999)
- Wallet list with icons, connection states, error handling, Escape to close
- Connected state shows address + disconnect button in navbar
- On-chain status cards: chain, queue length, total on-chain actions, pending txs
- Terminal shows tx signing status and digests
- Success/error toasts on transaction confirmation

### What the simulator provides

| Interface | Address | Purpose |
|-----------|---------|---------|
| Web UI | `http://localhost:3000` | 3D viewport, command buttons, module browser |
| TCP Serial | `localhost:8375` | Drop-in serial port replacement for R modules |
| WebSocket | `ws://localhost:3000/ws` | Real-time robot state to browser |
| REST API | `/api/state`, `/api/command`, `/api/modules` | Scripting and testing |

### How modules connect

```bash
# Terminal 1: start the simulator
cd simulator && npm install && npm run dev

# Terminal 2: run any hardware module
cd R1/hello-bittle && pnpm sim       # serial demo
cd R4/processor   && pnpm sim       # blockchain processor
cd R5/server      && pnpm sim       # WebSocket control
cd R7/part-a-offchain && pnpm sim   # Ed25519 auth
```

### Files added/changed

- `simulator/` — Next.js app, Three.js robot, custom server, Tailwind CSS
- `simulator/src/hooks/useOnChainAction.ts` — sign-then-animate hook with toast notifications
- `simulator/src/hooks/useOnChainQueue.ts` — polls ActionQueue shared object every 5s
- `simulator/src/components/NavbarWalletControls.tsx` — custom connect modal via React portal
- `simulator/src/components/Toast.tsx` — success/error toast system
- `simulator/src/lib/sui-dapp-kit.ts` — dapp-kit config + deployed contract addresses
- `simulator/.env.example` — testnet contract addresses
- `simulator/lib/virtual-serial.ts` — shared TCP adapter (64 lines, zero deps)
- `R1, R4, R5, R7` — added `src/sim.ts` entry points and `pnpm sim` scripts
- No changes to existing module source code, Move contracts, or solution branches

## Test plan

- [ ] `cd simulator && npm install && npm run dev` starts without errors
- [ ] `http://localhost:3000` loads the landing page with Sui.io-style design
- [ ] `/playground` without wallet shows "Connect your wallet to begin" prompt
- [ ] Connect Sui testnet wallet via the full-view modal
- [ ] `/playground` with wallet shows 3D robot viewport, control panel, and terminal
- [ ] Click any action button — wallet prompts to sign the transaction
- [ ] Robot only animates after transaction confirms on-chain
- [ ] Success toast appears: "sit confirmed on-chain"
- [ ] Reject a transaction — robot does not move, error toast shown
- [ ] All 12 action buttons and keyboard shortcuts (W/A/S/D/Space) trigger on-chain txs
- [ ] On-chain status cards show queue length updating
- [ ] Disconnect wallet — playground reverts to connect prompt
- [ ] `echo "ksit" | nc localhost 8375` returns `[OK] Sitting`
- [ ] Module browser at `/modules` renders all 10 module cards
- [ ] `npx next build` passes clean
- [ ] Existing `sui move build` and `sui move test` commands still pass