### PR TITLE
Fix deprecated functions in G1 scenario tests

### DIFF
--- a/G1/scenario/sources/hero.move
+++ b/G1/scenario/sources/hero.move
@@ -1,7 +1,7 @@
 module scenario::hero;
 
 use scenario::acl::Admins;
-use scenario::xp_tome::XPTome;
+use scenario::xp_tome::{Self, XPTome};
 
 public struct HERO() has drop;
 
@@ -43,11 +43,13 @@ public fun level_up(self: &mut Hero, tome: XPTome) {
     self.stamina = self.stamina + stamina;
 }
 
+#[test_only]
+use std::unit_test;
+#[test_only]
+use scenario::acl;
+
 #[test]
 fun test_mint() {
-    use sui::test_utils;
-    use scenario::acl;
-
     let admin = @0x11111;
     let hero_owner = @0x22222;
     let health = 100;
@@ -55,12 +57,11 @@ fun test_mint() {
 
     let admins = acl::new_admins_for_testing(admin);
     mint(&admins, health, stamina, hero_owner, &mut tx_context::new_from_hint(admin, 0, 0, 0, 0));
-    test_utils::destroy(admins);
+    unit_test::destroy(admins);
 }
 
 #[test]
 fun test_level_up() {
-    use scenario::xp_tome;
     let health = 100;
     let xp_health = 10;
     let stamina = 10;

--- a/G1/scenario/sources/xp_tome.move
+++ b/G1/scenario/sources/xp_tome.move
@@ -49,11 +49,13 @@ public fun new_for_testing(health: u64, stamina: u64): XPTome {
     }
 }
 
+#[test_only]
+use std::unit_test;
+#[test_only]
+use scenario::acl;
+
 #[test]
 fun test_new() {
-    use sui::test_utils;
-    use scenario::acl;
-
     let admin = @0x11111;
     let hero_owner = @0x22222;
     let health = 20;
@@ -62,5 +64,5 @@ fun test_new() {
 
     new(&admins, health, stamina, hero_owner, &mut tx_context::new_from_hint(admin, 0, 0, 0, 0));
 
-    test_utils::destroy(admins);
+    unit_test::destroy(admins);
 }

--- a/G1/scenario/tests/acl_tests.move
+++ b/G1/scenario/tests/acl_tests.move
@@ -20,7 +20,7 @@ fun test_add_admin() {
     let transferred = begin_effects.transferred_to_account();
     assert!(created.length() == 3);
     assert!(shared.length() == 1);
-    assert!(transferred.size() == 2);
+    assert!(transferred.length() == 2);
 
     // Task: Add admin `new_admin`
     {

--- a/G1/scenario/tests/hero_tests.move
+++ b/G1/scenario/tests/hero_tests.move
@@ -25,7 +25,7 @@ fun test_mint() {
 
     let mint_effects = scenario.next_tx(hero_owner);
     let mut transferred = mint_effects.transferred_to_account();
-    assert!(transferred.size() == 1);
+    assert!(transferred.length() == 1);
     let (hero_id, transferred_to) = transferred.pop();
     assert!(transferred_to == hero_owner);
     // Task: Check `Hero`'s fields
@@ -56,7 +56,7 @@ fun test_level_up() {
 
     let mint_effects = scenario.next_tx(hero_owner);
     let transferred = mint_effects.transferred_to_account();
-    assert!(transferred.size() == 2);
+    assert!(transferred.length() == 2);
     // Task: Apply `XPTome` to `Hero` and check updated stats.
     {
 


### PR DESCRIPTION
## Summary
- Replace `test_utils::destroy` with `std::unit_test::destroy` in source-level tests
- Replace `vec_map::size()` with `length()` in scenario test files