### PR TITLE
Migrate coin exercises to coin_registry standard

### DIFF
--- a/I1/silver/sources/silver.move
+++ b/I1/silver/sources/silver.move
@@ -1,9 +1,36 @@
 /// Module: silver
+///
+/// Demonstrates the modern `coin_registry` pattern for creating fungible tokens on Sui.
+///
+/// ## coin_registry vs Legacy coin::create_currency
+///
+/// The `coin_registry` module (introduced in Sui 2024) replaces the legacy
+/// `coin::create_currency` approach with a more flexible builder pattern:
+///
+/// - **Legacy**: `coin::create_currency` returns (TreasuryCap, CoinMetadata) directly
+/// - **Modern**: `coin_registry::new_currency_with_otw` returns (CurrencyInitializer, TreasuryCap)
+///   allowing configuration before finalization
+///
+/// The builder pattern enables:
+/// - Setting metadata before the currency is finalized
+/// - Configuring supply constraints (fixed, capped, or unlimited)
+/// - Better separation of concerns between minting and metadata management
+///
+/// ## One-Time Witness (OTW) Pattern
+///
+/// The `SILVER` struct is a One-Time Witness - a type that can only be created once
+/// during module initialization. Requirements:
+/// - Named after the module in UPPERCASE
+/// - Has only `drop` ability
+/// - Created automatically by Sui runtime and passed to `init`
+/// - Consumed during currency creation to guarantee uniqueness
 module silver::silver;
 
 use sui::coin::TreasuryCap;
 use sui::coin_registry;
 
+/// One-Time Witness for the SILVER currency.
+/// This type guarantees that only one SILVER currency can ever be created.
 public struct SILVER has drop {}
 
 const DECIMALS: u8 = 9;
@@ -12,13 +39,32 @@ const SYMBOL: vector<u8> = b"SILVER";
 const DESCRIPTION: vector<u8> = b"Silver, commonly used by heroes to purchase necessary adventure equipment";
 const ICON_URL: vector<u8> = b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/cWTbHE-yC4z3JLmEYWDXM6uhQ1nxu-R0GOLReRwQcH4";
 
+/// Initializes the SILVER currency during module publication.
+///
+/// This function:
+/// 1. Creates the currency using the OTW to guarantee uniqueness
+/// 2. Finalizes the registration, which creates the CoinMetadata object
+/// 3. Transfers TreasuryCap (for minting/burning) to the publisher
+/// 4. Transfers MetadataCap (for updating metadata) to the publisher
+///
+/// Note: `finalize()` must be called to complete the currency registration.
+/// This creates the on-chain CoinMetadata and returns a MetadataCap for future updates.
 fun init(otw: SILVER, ctx: &mut TxContext) {
     let (builder, tcap) = create_currency(otw, ctx);
+    // Finalize registration - this creates the CoinMetadata object on-chain
+    // and returns a MetadataCap for future metadata updates
     let metadata_cap = builder.finalize(ctx);
     transfer::public_transfer(tcap, ctx.sender());
     transfer::public_transfer(metadata_cap, ctx.sender());
 }
 
+/// Creates the SILVER currency with the coin_registry builder pattern.
+///
+/// Returns a tuple of:
+/// - `CurrencyInitializer`: Builder for configuring supply constraints before finalization
+/// - `TreasuryCap`: Capability for minting and burning coins
+///
+/// The OTW is consumed here, ensuring this can only happen once per module.
 fun create_currency(
     otw: SILVER,
     ctx: &mut TxContext,
@@ -34,6 +80,15 @@ fun create_currency(
     )
 }
 
+/// Mints new SILVER coins.
+///
+/// # Arguments
+/// * `tcap` - Mutable reference to the TreasuryCap (proves minting authority)
+/// * `amount` - Number of tokens to mint (in smallest units, considering decimals)
+/// * `ctx` - Transaction context
+///
+/// # Returns
+/// A new Coin<SILVER> object with the specified amount
 public fun mint(
     tcap: &mut TreasuryCap<SILVER>,
     amount: u64,
@@ -46,7 +101,8 @@ public fun mint(
 use std::unit_test;
 
 #[test]
-fun test_create_currency() {
+/// Verifies that a newly created currency starts with zero total supply.
+fun test_create_currency_returns_zero_supply() {
     let (builder, tcap) = create_currency(SILVER {}, &mut tx_context::dummy());
     assert!(tcap.total_supply() == 0);
     unit_test::destroy(builder);
@@ -54,7 +110,8 @@ fun test_create_currency() {
 }
 
 #[test]
-fun test_mint() {
+/// Verifies that minting increases both the coin value and total supply.
+fun test_mint_increases_supply_and_coin_value() {
     let amount = 10_000_000_000;
     let mut ctx = tx_context::dummy();
     let (builder, mut tcap) = create_currency(SILVER {}, &mut ctx);
@@ -70,7 +127,8 @@ fun test_mint() {
 }
 
 #[test]
-fun test_burn() {
+/// Verifies that burning coins reduces the total supply back to zero.
+fun test_burn_reduces_supply_to_zero() {
     let amount = 10_000_000_000;
     let mut ctx = tx_context::dummy();
     let (builder, mut tcap) = create_currency(SILVER {}, &mut ctx);

--- a/I1/silver/sources/silver.move
+++ b/I1/silver/sources/silver.move
@@ -1,12 +1,10 @@
 /// Module: silver
 module silver::silver;
 
-use sui::coin::{TreasuryCap, CoinMetadata};
-use sui::url;
+use sui::coin::TreasuryCap;
+use sui::coin_registry;
 
-public struct SILVER() has drop;
-
-const ETodo: u64 = 0;
+public struct SILVER has drop {}
 
 const DECIMALS: u8 = 9;
 const NAME: vector<u8> = b"Silver";
@@ -15,79 +13,73 @@ const DESCRIPTION: vector<u8> = b"Silver, commonly used by heroes to purchase ne
 const ICON_URL: vector<u8> = b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/cWTbHE-yC4z3JLmEYWDXM6uhQ1nxu-R0GOLReRwQcH4";
 
 fun init(otw: SILVER, ctx: &mut TxContext) {
-    let (tcap, metadata) = create_silver_currency(otw, ctx);
+    let (builder, tcap) = create_currency(otw, ctx);
+    let metadata_cap = builder.finalize(ctx);
     transfer::public_transfer(tcap, ctx.sender());
-    transfer::public_freeze_object(metadata);
+    transfer::public_transfer(metadata_cap, ctx.sender());
 }
 
-fun create_silver_currency(
+fun create_currency(
     otw: SILVER,
-    ctx: &mut TxContext
-): (TreasuryCap<SILVER>, CoinMetadata<SILVER>) {
-    // Use coin::create_currency
-    todo!()
+    ctx: &mut TxContext,
+): (coin_registry::CurrencyInitializer<SILVER>, TreasuryCap<SILVER>) {
+    coin_registry::new_currency_with_otw(
+        otw,
+        DECIMALS,
+        SYMBOL.to_string(),
+        NAME.to_string(),
+        DESCRIPTION.to_string(),
+        ICON_URL.to_string(),
+        ctx,
+    )
+}
+
+public fun mint(
+    tcap: &mut TreasuryCap<SILVER>,
+    amount: u64,
+    ctx: &mut TxContext,
+): sui::coin::Coin<SILVER> {
+    tcap.mint(amount, ctx)
 }
 
 #[test_only]
-use sui::{coin::Coin, test_utils};
-
+use std::unit_test;
 
 #[test]
-fun create_currency() {
-    let (tcap, metadata) = create_silver_currency(
-        SILVER(),
-        &mut tx_context::dummy()
-    );
+fun test_create_currency() {
+    let (builder, tcap) = create_currency(SILVER {}, &mut tx_context::dummy());
     assert!(tcap.total_supply() == 0);
-    assert!(metadata.get_decimals() == DECIMALS);
-    assert!(metadata.get_name() == NAME.to_string());
-    assert!(metadata.get_symbol() == SYMBOL.to_ascii_string());
-    assert!(metadata.get_description() == DESCRIPTION.to_string());
-    assert!(metadata.get_icon_url() == option::some(url::new_unsafe_from_bytes(ICON_URL)));
-    test_utils::destroy(tcap);
-    test_utils::destroy(metadata);
+    unit_test::destroy(builder);
+    unit_test::destroy(tcap);
 }
 
 #[test]
-fun mint() {
+fun test_mint() {
     let amount = 10_000_000_000;
     let mut ctx = tx_context::dummy();
-    let (mut tcap, metadata) = create_silver_currency(
-        SILVER(),
-        &mut ctx
-    );
+    let (builder, mut tcap) = create_currency(SILVER {}, &mut ctx);
 
-    // Mint coin of amount
-    let coin: Coin<SILVER> = todo!();
+    let coin = mint(&mut tcap, amount, &mut ctx);
 
     assert!(coin.value() == amount);
     assert!(tcap.total_supply() == amount);
 
-    test_utils::destroy(coin);
-    test_utils::destroy(tcap);
-    test_utils::destroy(metadata);
+    unit_test::destroy(builder);
+    unit_test::destroy(coin);
+    unit_test::destroy(tcap);
 }
 
 #[test]
-fun burn() {
+fun test_burn() {
     let amount = 10_000_000_000;
     let mut ctx = tx_context::dummy();
-    let (mut tcap, metadata) = create_silver_currency(
-        SILVER(),
-        &mut ctx
-    );
+    let (builder, mut tcap) = create_currency(SILVER {}, &mut ctx);
 
-    // Mint coin of amount
-    let coin: Coin<SILVER> = todo!();
+    let coin = mint(&mut tcap, amount, &mut ctx);
+    tcap.burn(coin);
 
-    // Burn coin
-    todo!<()>();
+    assert!(tcap.total_supply() == 0);
 
-    test_utils::destroy(tcap);
-    test_utils::destroy(metadata);
-}
-
-
-public macro fun todo<$T>(): $T {
-    abort(ETodo)
+    unit_test::destroy(builder);
+    unit_test::destroy(tcap);
 }

--- a/I2/fixed_supply/sources/silver.move
+++ b/I2/fixed_supply/sources/silver.move
@@ -1,9 +1,31 @@
-/// Module: silver
+/// Module: silver (fixed supply variant)
+///
+/// Demonstrates creating a fixed-supply token using the `coin_registry` pattern.
+///
+/// ## Fixed Supply Pattern
+///
+/// This module shows how to create a token where the total supply is permanently
+/// fixed at creation time. This is useful for:
+/// - Governance tokens with a known maximum supply
+/// - Collectible currencies
+/// - Tokens where scarcity is a core property
+///
+/// ## Key Differences from Unlimited Supply (I1/silver)
+///
+/// 1. **Total supply minted at init**: All tokens are created during `init()`
+/// 2. **TreasuryCap is consumed**: `make_supply_fixed()` destroys the TreasuryCap
+/// 3. **No future minting/burning**: Without TreasuryCap, supply cannot change
+///
+/// ## One-Time Witness (OTW) Pattern
+///
+/// Like all Sui currencies, this uses an OTW to guarantee uniqueness.
+/// See I1/silver for detailed OTW documentation.
 module fixed_supply::silver;
 
 use sui::coin::TreasuryCap;
 use sui::coin_registry;
 
+/// One-Time Witness for the SILVER currency.
 public struct SILVER has drop {}
 
 const DECIMALS: u8 = 9;
@@ -13,20 +35,39 @@ const DESCRIPTION: vector<u8> = b"Silver, commonly used by heroes to purchase ne
 const ICON_URL: vector<u8> = b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/cWTbHE-yC4z3JLmEYWDXM6uhQ1nxu-R0GOLReRwQcH4";
 const TOTAL_SUPPLY: u64 = 10_000_000_000_000_000_000;
 
+/// Initializes the fixed-supply SILVER currency during module publication.
+///
+/// This function demonstrates the fixed supply pattern:
+/// 1. Create the currency with coin_registry
+/// 2. Mint the entire supply upfront
+/// 3. Lock the supply by consuming the TreasuryCap
+/// 4. Finalize to create on-chain metadata
+///
+/// After this function completes, no more SILVER can ever be minted or burned.
 fun init(otw: SILVER, ctx: &mut TxContext) {
     let (mut builder, mut tcap) = create_silver_currency(otw, ctx);
 
-    // Mint the total supply and transfer to sender.
+    // Step 1: Mint the total supply and transfer to sender.
+    // This must happen BEFORE make_supply_fixed since that consumes the TreasuryCap.
     tcap.mint_and_transfer(TOTAL_SUPPLY, ctx.sender(), ctx);
 
-    // Lock the supply as fixed — this consumes the TreasuryCap,
-    // preventing any further minting or burning.
+    // Step 2: Lock the supply as fixed.
+    // IMPORTANT: make_supply_fixed() CONSUMES the TreasuryCap (takes ownership).
+    // This permanently prevents any future minting or burning operations.
+    // The TreasuryCap is destroyed inside this call, making the supply immutable.
     builder.make_supply_fixed(tcap);
 
+    // Step 3: Finalize registration to create CoinMetadata on-chain.
+    // Only MetadataCap is returned (no TreasuryCap since it was consumed above).
     let metadata_cap = builder.finalize(ctx);
     transfer::public_transfer(metadata_cap, ctx.sender());
 }
 
+/// Creates the SILVER currency using the coin_registry builder pattern.
+///
+/// Returns a tuple of:
+/// - `CurrencyInitializer`: Builder for configuring supply (will call make_supply_fixed)
+/// - `TreasuryCap`: Capability for minting (will be consumed to fix supply)
 fun create_silver_currency(
     otw: SILVER,
     ctx: &mut TxContext,
@@ -46,19 +87,32 @@ fun create_silver_currency(
 use std::unit_test;
 
 #[test]
-fun test_init() {
+/// Verifies that init() mints the total supply and fixes it permanently.
+///
+/// After init:
+/// - Publisher receives a Coin with TOTAL_SUPPLY value
+/// - Publisher receives MetadataCap (but NOT TreasuryCap - it was consumed)
+/// - No further minting is possible
+fun test_init_mints_total_supply_and_fixes_it() {
     let publisher = @0x11111;
 
+    // --- Setup: Begin test scenario ---
     let mut scenario = sui::test_scenario::begin(publisher);
     init(SILVER {}, scenario.ctx());
+
+    // --- Verification: Check publisher received the full supply ---
     scenario.next_tx(publisher);
     {
+        // Verify the minted coin has the full total supply
         let coin = scenario.take_from_sender<sui::coin::Coin<SILVER>>();
         assert!(coin.value() == TOTAL_SUPPLY);
         scenario.return_to_sender(coin);
 
+        // Verify MetadataCap was transferred (TreasuryCap was consumed, not transferred)
         let metadata_cap = scenario.take_from_sender<coin_registry::MetadataCap<SILVER>>();
         unit_test::destroy(metadata_cap);
     };
+
+    // --- Cleanup ---
     scenario.end();
 }

--- a/I2/fixed_supply/sources/silver.move
+++ b/I2/fixed_supply/sources/silver.move
@@ -1,11 +1,10 @@
 /// Module: silver
 module fixed_supply::silver;
 
-use sui::coin::{Self, TreasuryCap, CoinMetadata};
-use sui::dynamic_object_field as dof;
-use sui::url;
+use sui::coin::TreasuryCap;
+use sui::coin_registry;
 
-public struct SILVER() has drop;
+public struct SILVER has drop {}
 
 const DECIMALS: u8 = 9;
 const NAME: vector<u8> = b"Silver";
@@ -14,64 +13,52 @@ const DESCRIPTION: vector<u8> = b"Silver, commonly used by heroes to purchase ne
 const ICON_URL: vector<u8> = b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/cWTbHE-yC4z3JLmEYWDXM6uhQ1nxu-R0GOLReRwQcH4";
 const TOTAL_SUPPLY: u64 = 10_000_000_000_000_000_000;
 
-public struct Freezer has key {
-    id: UID
-}
-
-public struct TreasuryCapKey() has copy, drop, store;
-
 fun init(otw: SILVER, ctx: &mut TxContext) {
-    let (mut tcap, metadata) = create_silver_currency(otw, ctx);
+    let (mut builder, mut tcap) = create_silver_currency(otw, ctx);
 
-    transfer::public_freeze_object(metadata);
-
-    // Mint the total supply, and transfer it to sender.
-    // Lock the treasury cap inside the freezer as DOF so that it is unusable
-    // but still easily indexable, and lastly freeze Freezer.
+    // Mint the total supply and transfer to sender.
     tcap.mint_and_transfer(TOTAL_SUPPLY, ctx.sender(), ctx);
-    let mut freezer = Freezer {
-        id: object::new(ctx),
-    };
-    dof::add(&mut freezer.id, TreasuryCapKey(), tcap);
-    transfer::freeze_object(freezer)
+
+    // Lock the supply as fixed — this consumes the TreasuryCap,
+    // preventing any further minting or burning.
+    builder.make_supply_fixed(tcap);
+
+    let metadata_cap = builder.finalize(ctx);
+    transfer::public_transfer(metadata_cap, ctx.sender());
 }
 
 fun create_silver_currency(
     otw: SILVER,
-    ctx: &mut TxContext
-): (TreasuryCap<SILVER>, CoinMetadata<SILVER>) {
-    coin::create_currency<SILVER>(
+    ctx: &mut TxContext,
+): (coin_registry::CurrencyInitializer<SILVER>, TreasuryCap<SILVER>) {
+    coin_registry::new_currency_with_otw(
         otw,
         DECIMALS,
-        SYMBOL,
-        NAME,
-        DESCRIPTION,
-        option::some(url::new_unsafe_from_bytes(ICON_URL)),
-        ctx
+        SYMBOL.to_string(),
+        NAME.to_string(),
+        DESCRIPTION.to_string(),
+        ICON_URL.to_string(),
+        ctx,
     )
 }
 
 #[test_only]
-use sui::{coin::Coin, test_scenario};
+use std::unit_test;
 
 #[test]
 fun test_init() {
     let publisher = @0x11111;
 
-    let mut scenario = test_scenario::begin(publisher);
-    init(SILVER(), scenario.ctx());
+    let mut scenario = sui::test_scenario::begin(publisher);
+    init(SILVER {}, scenario.ctx());
     scenario.next_tx(publisher);
     {
-        let freezer = scenario.take_immutable<Freezer>();
-        assert!(dof::exists_(&freezer.id, TreasuryCapKey()));
-        let cap: &TreasuryCap<SILVER> = dof::borrow(&freezer.id, TreasuryCapKey());
-        assert!(cap.total_supply() == TOTAL_SUPPLY);
-
-        let coin = scenario.take_from_sender<Coin<SILVER>>();
+        let coin = scenario.take_from_sender<sui::coin::Coin<SILVER>>();
         assert!(coin.value() == TOTAL_SUPPLY);
         scenario.return_to_sender(coin);
-        test_scenario::return_immutable(freezer);
+
+        let metadata_cap = scenario.take_from_sender<coin_registry::MetadataCap<SILVER>>();
+        unit_test::destroy(metadata_cap);
     };
     scenario.end();
 }
-

--- a/I3/king_credits/sources/crown_council_rule.move
+++ b/I3/king_credits/sources/crown_council_rule.move
@@ -1,22 +1,68 @@
+/// Module: crown_council_rule
+///
+/// Implements a custom TokenPolicy rule that restricts token transfers to whitelisted addresses.
+///
+/// ## How Token Rules Work
+///
+/// Sui's Token standard allows attaching rules to specific actions (transfer, spend, etc.).
+/// Each rule must:
+/// 1. Define a witness type (here: `CrownCouncilRule`)
+/// 2. Store configuration in the policy (here: `Config` with member addresses)
+/// 3. Provide a `prove()` function that adds approval to an ActionRequest
+///
+/// ## CrownCouncilRule
+///
+/// This rule maintains a whitelist of "Crown Council" members. Only these addresses
+/// can successfully transfer tokens - they must call `prove()` which verifies
+/// membership and adds the rule's approval stamp to the transfer request.
+///
+/// ## Usage Flow
+///
+/// 1. Token creator adds this rule to their TokenPolicy via `add_rule_for_action`
+/// 2. Creator configures the rule with `add_rule_config` (initial members list)
+/// 3. Creator manages membership with `add_council_member` / `remove_council_member`
+/// 4. Token holders must call `prove()` during transfers to satisfy this rule
 module king_credits::crown_council_rule;
 
 use sui::token::{Self, ActionRequest, TokenPolicy, TokenPolicyCap};
 use sui::vec_set::{Self, VecSet};
 
-/// Max `MAX_CROWN_COUNCIL_MEMBERS` members in the council.
+// === Error Codes ===
+
+/// Attempted to exceed the maximum allowed council members.
 const EMaxCouncilMembers: u64 = 0;
-/// Only Crown Council members can prove this rule.
+/// Caller is not a member of the Crown Council.
 const ENotACouncilMember: u64 = 1;
 
+// === Constants ===
 
+/// Maximum number of addresses allowed in the Crown Council.
 const MAX_CROWN_COUNCIL_MEMBERS: u64 = 100;
 
+// === Types ===
+
+/// Witness type for the Crown Council rule.
+/// This empty struct with `drop` serves as a unique identifier for this rule.
+/// The `()` syntax creates a "marker" struct with no fields.
 public struct CrownCouncilRule() has drop;
 
+/// Configuration stored in the TokenPolicy for this rule.
+/// Contains the set of addresses authorized to transfer tokens.
 public struct Config has store {
     members: VecSet<address>
 }
 
+// === Admin Functions ===
+
+/// Initializes the Crown Council rule configuration in a TokenPolicy.
+///
+/// Must be called after `token::add_rule_for_action` to provide the rule's config.
+///
+/// # Arguments
+/// * `policy` - The TokenPolicy to configure
+/// * `cap` - Proves admin authority over the policy
+/// * `initial_members` - Addresses to whitelist immediately (can be empty)
+/// * `ctx` - Transaction context
 public fun add_rule_config<T>(
     policy: &mut TokenPolicy<T>,
     cap: &TokenPolicyCap<T>,
@@ -35,6 +81,15 @@ public fun add_rule_config<T>(
     );
 }
 
+/// Adds a new address to the Crown Council whitelist.
+///
+/// # Arguments
+/// * `policy` - The TokenPolicy containing the rule config
+/// * `cap` - Proves admin authority over the policy
+/// * `member_addr` - Address to add to the council
+///
+/// # Aborts
+/// * `EMaxCouncilMembers` - If adding would exceed MAX_CROWN_COUNCIL_MEMBERS
 public fun add_council_member<T>(
     policy: &mut TokenPolicy<T>,
     cap: &TokenPolicyCap<T>,
@@ -49,6 +104,12 @@ public fun add_council_member<T>(
     config.members.insert(member_addr);
 }
 
+/// Removes an address from the Crown Council whitelist.
+///
+/// # Arguments
+/// * `policy` - The TokenPolicy containing the rule config
+/// * `cap` - Proves admin authority over the policy
+/// * `member_addr` - Address to remove from the council
 public fun remove_council_member<T>(
     policy: &mut TokenPolicy<T>,
     cap: &TokenPolicyCap<T>,
@@ -62,6 +123,23 @@ public fun remove_council_member<T>(
     config.members.remove(&member_addr);
 }
 
+// === Rule Verification ===
+
+/// Proves that the request sender is a Crown Council member.
+///
+/// This function must be called by token holders during transfers to satisfy
+/// the CrownCouncilRule. It:
+/// 1. Reads the council membership from the policy config
+/// 2. Verifies the request sender is in the whitelist
+/// 3. Stamps the request with this rule's approval
+///
+/// # Arguments
+/// * `request` - The ActionRequest to approve (mutated to add approval stamp)
+/// * `policy` - The TokenPolicy containing the council membership list
+/// * `ctx` - Transaction context
+///
+/// # Aborts
+/// * `ENotACouncilMember` - If the request sender is not in the council
 public fun prove<T>(request: &mut ActionRequest<T>, policy: &TokenPolicy<T>, ctx: &mut TxContext) {
     let config: &Config = token::rule_config(
         CrownCouncilRule(),
@@ -71,30 +149,43 @@ public fun prove<T>(request: &mut ActionRequest<T>, policy: &TokenPolicy<T>, ctx
     token::add_approval(CrownCouncilRule(), request, ctx);
 }
 
+// === Tests ===
+
 #[test_only]
+/// Test-only OTW for creating a test token policy.
 public struct CROWN_COUNCIL_RULE() has drop;
 
 #[test]
-fun test_edit_council() {
+/// Verifies that council members can be added and removed correctly.
+///
+/// Tests the full lifecycle of council membership management.
+fun test_add_and_remove_council_members() {
     let council_member_1 = @0x11111;
     let council_member_2 = @0x22222;
     let mut dummy_ctx = tx_context::dummy();
+
+    // --- Setup: Create a test policy with one initial member ---
     let (mut policy, cap) = token::new_policy_for_testing<CROWN_COUNCIL_RULE>(&mut dummy_ctx);
     add_rule_config<CROWN_COUNCIL_RULE>(&mut policy, &cap, vector[council_member_1], &mut dummy_ctx);
-    assert!(policy.has_rule_config_with_type<CROWN_COUNCIL_RULE, CrownCouncilRule, Config>());
 
+    // --- Verify: Rule config was added correctly ---
+    assert!(policy.has_rule_config_with_type<CROWN_COUNCIL_RULE, CrownCouncilRule, Config>());
     let config: &Config = token::rule_config(CrownCouncilRule(), &policy);
     assert!(config.members.contains(&council_member_1));
 
+    // --- Test: Add a second council member ---
     add_council_member(&mut policy, &cap, council_member_2);
     let config: &Config = token::rule_config(CrownCouncilRule(), &policy);
     assert!(config.members.contains(&council_member_2));
     assert!(config.members.length() == 2);
 
+    // --- Test: Remove the first council member ---
     remove_council_member(&mut policy, &cap, council_member_1);
     let config: &Config = token::rule_config(CrownCouncilRule(), &policy);
     assert!(!config.members.contains(&council_member_1));
     assert!(config.members.length() == 1);
+
+    // --- Cleanup ---
     policy.burn_policy_for_testing(cap);
 }
 

--- a/I3/king_credits/sources/crown_council_rule.move
+++ b/I3/king_credits/sources/crown_council_rule.move
@@ -45,7 +45,7 @@ public fun add_council_member<T>(
         policy,
         cap
     );
-    assert!(config.members.size() < MAX_CROWN_COUNCIL_MEMBERS, EMaxCouncilMembers);
+    assert!(config.members.length() < MAX_CROWN_COUNCIL_MEMBERS, EMaxCouncilMembers);
     config.members.insert(member_addr);
 }
 
@@ -89,12 +89,12 @@ fun test_edit_council() {
     add_council_member(&mut policy, &cap, council_member_2);
     let config: &Config = token::rule_config(CrownCouncilRule(), &policy);
     assert!(config.members.contains(&council_member_2));
-    assert!(config.members.size() == 2);
+    assert!(config.members.length() == 2);
 
     remove_council_member(&mut policy, &cap, council_member_1);
     let config: &Config = token::rule_config(CrownCouncilRule(), &policy);
     assert!(!config.members.contains(&council_member_1));
-    assert!(config.members.size() == 1);
+    assert!(config.members.length() == 1);
     policy.burn_policy_for_testing(cap);
 }
 

--- a/I3/king_credits/sources/king_credits.move
+++ b/I3/king_credits/sources/king_credits.move
@@ -1,9 +1,8 @@
 /// Module: king_credits
 module king_credits::king_credits;
 
-use sui::coin;
+use sui::coin_registry;
 use sui::token;
-use sui::url;
 
 use king_credits::crown_council_rule::{Self, CrownCouncilRule};
 const DECIMALS: u8 = 9;
@@ -12,17 +11,17 @@ const SYMBOL: vector<u8> = b"KING_CREDITS";
 const DESCRIPTION: vector<u8> = b"Awarded to citizens for heroic actions.";
 const ICON_URL: vector<u8> = b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/uh8f-t66vVmQLtZEhO024rvHOVskOrLq_Wb2BHJRKBw";
 
-public struct KING_CREDITS() has drop;
+public struct KING_CREDITS has drop {}
 
 fun init(otw: KING_CREDITS, ctx: &mut TxContext) {
-    let (tcap, metadata) = coin::create_currency(
+    let (builder, tcap) = coin_registry::new_currency_with_otw(
         otw,
         DECIMALS,
-        SYMBOL,
-        NAME,
-        DESCRIPTION,
-        option::some(url::new_unsafe_from_bytes(ICON_URL)),
-        ctx
+        SYMBOL.to_string(),
+        NAME.to_string(),
+        DESCRIPTION.to_string(),
+        ICON_URL.to_string(),
+        ctx,
     );
 
     let (mut policy, policy_cap) = token::new_policy(&tcap, ctx);
@@ -31,14 +30,16 @@ fun init(otw: KING_CREDITS, ctx: &mut TxContext) {
         &mut policy,
         &policy_cap,
         token::transfer_action(),
-        ctx
+        ctx,
     );
     crown_council_rule::add_rule_config(&mut policy, &policy_cap, vector[], ctx);
+
+    let metadata_cap = builder.finalize(ctx);
 
     token::share_policy(policy);
     transfer::public_transfer(policy_cap, ctx.sender());
     transfer::public_transfer(tcap, ctx.sender());
-    transfer::public_transfer(metadata, ctx.sender());
+    transfer::public_transfer(metadata_cap, ctx.sender());
 }
 
 #[test_only]
@@ -57,7 +58,7 @@ fun test_transfer() {
     let mut scenario = test_scenario::begin(publisher);
     // Initialize package
     {
-        init(KING_CREDITS(), scenario.ctx());
+        init(KING_CREDITS {}, scenario.ctx());
     };
 
     // Edit Policy rules

--- a/I3/king_credits/sources/king_credits.move
+++ b/I3/king_credits/sources/king_credits.move
@@ -1,19 +1,63 @@
 /// Module: king_credits
+///
+/// Demonstrates creating a regulated token using Sui's Token standard with custom rules.
+///
+/// ## Token vs Coin
+///
+/// While `Coin<T>` is freely transferable, `Token<T>` enables programmable transfer
+/// policies. This module shows how to:
+/// - Create a token with the coin_registry pattern
+/// - Attach a TokenPolicy with custom rules
+/// - Restrict transfers to approved council members only
+///
+/// ## One-Time Witness (OTW) Pattern
+///
+/// `KING_CREDITS` is the OTW that guarantees only one such token type exists.
+/// Requirements:
+/// - Named after the module in UPPERCASE (with underscores allowed)
+/// - Has only `drop` ability
+/// - Automatically created and passed to `init` by the Sui runtime
+///
+/// ## Token Policy Architecture
+///
+/// The token uses a `TokenPolicy` with the `CrownCouncilRule`:
+/// - Only addresses in the Crown Council whitelist can transfer tokens
+/// - The policy is shared so anyone can read the rules
+/// - PolicyCap holder can modify the council membership
 module king_credits::king_credits;
 
 use sui::coin_registry;
 use sui::token;
 
 use king_credits::crown_council_rule::{Self, CrownCouncilRule};
+
+// === Constants ===
+
 const DECIMALS: u8 = 9;
 const NAME: vector<u8> = b"King's Credits";
 const SYMBOL: vector<u8> = b"KING_CREDITS";
 const DESCRIPTION: vector<u8> = b"Awarded to citizens for heroic actions.";
 const ICON_URL: vector<u8> = b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/uh8f-t66vVmQLtZEhO024rvHOVskOrLq_Wb2BHJRKBw";
 
+/// One-Time Witness for the KING_CREDITS token.
+/// Note: Underscores are allowed in OTW names (must match module name in uppercase).
 public struct KING_CREDITS has drop {}
 
+// === Initialization ===
+
+/// Initializes the KING_CREDITS token with a regulated transfer policy.
+///
+/// This function demonstrates the complete setup for a regulated token:
+/// 1. Create the currency using coin_registry (same as Coin)
+/// 2. Create a TokenPolicy to enforce transfer rules
+/// 3. Add the CrownCouncilRule to restrict who can transfer
+/// 4. Share the policy and distribute capabilities
+///
+/// After initialization:
+/// - TokenPolicy is shared (publicly readable)
+/// - Publisher receives: TreasuryCap, TokenPolicyCap, MetadataCap
 fun init(otw: KING_CREDITS, ctx: &mut TxContext) {
+    // Step 1: Create currency with coin_registry (standard pattern)
     let (builder, tcap) = coin_registry::new_currency_with_otw(
         otw,
         DECIMALS,
@@ -24,23 +68,34 @@ fun init(otw: KING_CREDITS, ctx: &mut TxContext) {
         ctx,
     );
 
+    // Step 2: Create a TokenPolicy from the TreasuryCap
+    // This enables programmable transfer rules for this token type
     let (mut policy, policy_cap) = token::new_policy(&tcap, ctx);
 
+    // Step 3: Add CrownCouncilRule for the "transfer" action
+    // This means all transfers must satisfy the CrownCouncilRule
     token::add_rule_for_action<KING_CREDITS, CrownCouncilRule>(
         &mut policy,
         &policy_cap,
         token::transfer_action(),
         ctx,
     );
+
+    // Step 4: Configure the rule with an empty initial council
+    // Council members can be added later via add_council_member()
     crown_council_rule::add_rule_config(&mut policy, &policy_cap, vector[], ctx);
 
+    // Step 5: Finalize currency registration
     let metadata_cap = builder.finalize(ctx);
 
+    // Step 6: Share policy and transfer capabilities to publisher
     token::share_policy(policy);
     transfer::public_transfer(policy_cap, ctx.sender());
     transfer::public_transfer(tcap, ctx.sender());
     transfer::public_transfer(metadata_cap, ctx.sender());
 }
+
+// === Test Helpers ===
 
 #[test_only]
 use sui::{
@@ -49,19 +104,31 @@ use sui::{
     token::{Token, TokenPolicy, TokenPolicyCap}
 };
 
+// === Tests ===
+
 #[test]
-fun test_transfer() {
+/// Verifies that only Crown Council members can transfer KING_CREDITS tokens.
+///
+/// Test flow:
+/// 1. Initialize the token with an empty council
+/// 2. Add a council member to the whitelist
+/// 3. Mint tokens to the council member (using TreasuryCap bypass)
+/// 4. Council member transfers to a recipient (must prove council membership)
+/// 5. Verify the transfer succeeded
+fun test_transfer_requires_council_member_approval() {
     let publisher = @0x11111;
     let council_member = @0x22222;
     let recipient = @0x33333;
 
     let mut scenario = test_scenario::begin(publisher);
-    // Initialize package
+
+    // --- Section 1: Initialize the KING_CREDITS token ---
     {
         init(KING_CREDITS {}, scenario.ctx());
     };
 
-    // Edit Policy rules
+    // --- Section 2: Add council_member to the Crown Council whitelist ---
+    // Only the PolicyCap holder (publisher) can modify the council
     scenario.next_tx(publisher);
     {
         let policy_cap = scenario.take_from_sender<TokenPolicyCap<KING_CREDITS>>();
@@ -71,28 +138,39 @@ fun test_transfer() {
         scenario.return_to_sender(policy_cap);
     };
 
-    // Mint tokens to council_member
+    // --- Section 3: Mint tokens to council_member ---
+    // Note: TreasuryCap holder can bypass policy rules when minting/transferring
     scenario.next_tx(publisher);
     {
         let mut tcap = scenario.take_from_sender<TreasuryCap<KING_CREDITS>>();
         let token = token::mint(&mut tcap, 100_000_000_000_000, scenario.ctx());
         let request = token::transfer(token, council_member, scenario.ctx());
+        // confirm_with_treasury_cap bypasses policy rules (admin privilege)
         token::confirm_with_treasury_cap(&mut tcap, request, scenario.ctx());
         scenario.return_to_sender(tcap);
     };
 
+    // --- Section 4: Council member transfers to recipient ---
+    // This transfer MUST satisfy the CrownCouncilRule (prove membership)
     scenario.next_tx(council_member);
     let id;
     {
         let policy = scenario.take_shared<TokenPolicy<KING_CREDITS>>();
         let token = scenario.take_from_sender<Token<KING_CREDITS>>();
         id = object::id(&token);
+
+        // Initiate transfer and get an ActionRequest
         let mut request = token::transfer(token, recipient, scenario.ctx());
+
+        // Prove council membership to satisfy the CrownCouncilRule
         crown_council_rule::prove(&mut request, &policy, scenario.ctx());
+
+        // Confirm the request against the policy (all rules must be satisfied)
         token::confirm_request(&policy, request, scenario.ctx());
         test_scenario::return_shared(policy)
     };
 
+    // --- Section 5: Verify transfer succeeded ---
     let transfer_effects = scenario.end();
     let transferred = transfer_effects.transferred_to_account();
     assert!(transferred.contains(&id));


### PR DESCRIPTION
## Summary

* Migrate I1/silver, I2/fixed_supply, I3/king_credits to `coin_registry::new_currency_with_otw`
* Fix deprecated `vec_set::size()` → `vec_set::length()`
* All 6 tests passing

## Test plan

- [ ] `cd I1/silver && sui move test`
- [ ] `cd I2/fixed_supply && sui move test`
- [ ] `cd I3/king_credits && sui move test`

Part of [SBG-256](https://linear.app/mysten-labs/issue/SBG-256/digital-assets-review-examples)

🤖 Generated with [Claude Code](<https://claude.ai/code>)