### PR TITLE
Update coin exercises scaffolding for coin_registry

### DIFF
--- a/I1/silver/sources/silver.move
+++ b/I1/silver/sources/silver.move
@@ -27,6 +27,7 @@ fun create_currency(
 ): (coin_registry::CurrencyInitializer<SILVER>, TreasuryCap<SILVER>) {
     // Task: Use coin_registry::new_currency_with_otw to create a new currency
     // with the constants defined above. String arguments should use .to_string()
+    // Hint: Returns (CurrencyInitializer<SILVER>, TreasuryCap<SILVER>) tuple
     todo!()
 }
 
@@ -36,6 +37,7 @@ public fun mint(
     ctx: &mut TxContext,
 ): sui::coin::Coin<SILVER> {
     // Task: Mint `amount` coins using the TreasuryCap
+    // This creates new coins and increases total_supply. Use tcap.mint(amount, ctx)
     todo!()
 }
 
@@ -56,8 +58,7 @@ fun test_mint() {
     let mut ctx = tx_context::dummy();
     let (builder, mut tcap) = create_currency(SILVER {}, &mut ctx);
 
-    // Task: Call mint to get a coin of `amount`
-    let coin: sui::coin::Coin<SILVER> = todo!();
+    let coin = mint(&mut tcap, amount, &mut ctx);
 
     assert!(coin.value() == amount);
     assert!(tcap.total_supply() == amount);
@@ -84,6 +85,6 @@ fun test_burn() {
     unit_test::destroy(tcap);
 }
 
-public macro fun todo<$T>(): $T {
+macro fun todo<$T>(): $T {
     abort(ETodo)
 }

--- a/I1/silver/sources/silver.move
+++ b/I1/silver/sources/silver.move
@@ -1,10 +1,10 @@
 /// Module: silver
 module silver::silver;
 
-use sui::coin::{TreasuryCap, CoinMetadata};
-use sui::url;
+use sui::coin::TreasuryCap;
+use sui::coin_registry;
 
-public struct SILVER() has drop;
+public struct SILVER has drop {}
 
 const ETodo: u64 = 0;
 
@@ -15,78 +15,74 @@ const DESCRIPTION: vector<u8> = b"Silver, commonly used by heroes to purchase ne
 const ICON_URL: vector<u8> = b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/cWTbHE-yC4z3JLmEYWDXM6uhQ1nxu-R0GOLReRwQcH4";
 
 fun init(otw: SILVER, ctx: &mut TxContext) {
-    let (tcap, metadata) = create_silver_currency(otw, ctx);
+    let (builder, tcap) = create_currency(otw, ctx);
+    let metadata_cap = builder.finalize(ctx);
     transfer::public_transfer(tcap, ctx.sender());
-    transfer::public_freeze_object(metadata);
+    transfer::public_transfer(metadata_cap, ctx.sender());
 }
 
-fun create_silver_currency(
+fun create_currency(
     otw: SILVER,
-    ctx: &mut TxContext
-): (TreasuryCap<SILVER>, CoinMetadata<SILVER>) {
-    // Task: Use coin::create_currency
+    ctx: &mut TxContext,
+): (coin_registry::CurrencyInitializer<SILVER>, TreasuryCap<SILVER>) {
+    // Task: Use coin_registry::new_currency_with_otw to create a new currency
+    // with the constants defined above. String arguments should use .to_string()
+    todo!()
+}
+
+public fun mint(
+    tcap: &mut TreasuryCap<SILVER>,
+    amount: u64,
+    ctx: &mut TxContext,
+): sui::coin::Coin<SILVER> {
+    // Task: Mint `amount` coins using the TreasuryCap
     todo!()
 }
 
 #[test_only]
-use sui::{coin::Coin, test_utils};
-
+use std::unit_test;
 
 #[test]
-fun create_currency() {
-    let (tcap, metadata) = create_silver_currency(
-        SILVER(),
-        &mut tx_context::dummy()
-    );
+fun test_create_currency() {
+    let (builder, tcap) = create_currency(SILVER {}, &mut tx_context::dummy());
     assert!(tcap.total_supply() == 0);
-    assert!(metadata.get_decimals() == DECIMALS);
-    assert!(metadata.get_name() == NAME.to_string());
-    assert!(metadata.get_symbol() == SYMBOL.to_ascii_string());
-    assert!(metadata.get_description() == DESCRIPTION.to_string());
-    assert!(metadata.get_icon_url() == option::some(url::new_unsafe_from_bytes(ICON_URL)));
-    test_utils::destroy(tcap);
-    test_utils::destroy(metadata);
+    unit_test::destroy(builder);
+    unit_test::destroy(tcap);
 }
 
 #[test]
-fun mint() {
+fun test_mint() {
     let amount = 10_000_000_000;
     let mut ctx = tx_context::dummy();
-    let (mut tcap, metadata) = create_silver_currency(
-        SILVER(),
-        &mut ctx
-    );
+    let (builder, mut tcap) = create_currency(SILVER {}, &mut ctx);
 
-    // Task: Mint coin of amount
-    let coin: Coin<SILVER> = todo!();
+    // Task: Call mint to get a coin of `amount`
+    let coin: sui::coin::Coin<SILVER> = todo!();
 
     assert!(coin.value() == amount);
     assert!(tcap.total_supply() == amount);
 
-    test_utils::destroy(coin);
-    test_utils::destroy(tcap);
-    test_utils::destroy(metadata);
+    unit_test::destroy(builder);
+    unit_test::destroy(coin);
+    unit_test::destroy(tcap);
 }
 
 #[test]
-fun burn() {
+fun test_burn() {
     let amount = 10_000_000_000;
     let mut ctx = tx_context::dummy();
-    let (mut tcap, metadata) = create_silver_currency(
-        SILVER(),
-        &mut ctx
-    );
+    let (builder, mut tcap) = create_currency(SILVER {}, &mut ctx);
 
-    // Mint coin of amount
-    let coin: Coin<SILVER> = todo!();
+    let coin = mint(&mut tcap, amount, &mut ctx);
 
-    // Task: Burn coin
+    // Task: Burn the coin using the TreasuryCap
     todo!<()>();
 
-    test_utils::destroy(tcap);
-    test_utils::destroy(metadata);
-}
+    assert!(tcap.total_supply() == 0);
 
+    unit_test::destroy(builder);
+    unit_test::destroy(tcap);
+}
 
 public macro fun todo<$T>(): $T {
     abort(ETodo)

--- a/I2/fixed_supply/sources/silver.move
+++ b/I2/fixed_supply/sources/silver.move
@@ -1,8 +1,10 @@
 /// Module: silver
 module fixed_supply::silver;
 
-use sui::coin::{Self, TreasuryCap, CoinMetadata};
-use sui::url;
+use sui::coin::TreasuryCap;
+use sui::coin_registry;
+
+public struct SILVER has drop {}
 
 const ETodo: u64 = 0;
 
@@ -13,65 +15,52 @@ const DESCRIPTION: vector<u8> = b"Silver, commonly used by heroes to purchase ne
 const ICON_URL: vector<u8> = b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/cWTbHE-yC4z3JLmEYWDXM6uhQ1nxu-R0GOLReRwQcH4";
 const TOTAL_SUPPLY: u64 = 10_000_000_000_000_000_000;
 
-public struct SILVER() has drop;
-
-public struct Freezer has key {
-    id: UID
-}
-
-public struct TreasuryCapKey() has copy, drop, store;
-
 fun init(otw: SILVER, ctx: &mut TxContext) {
-    let (tcap, metadata) = create_silver_currency(otw, ctx);
+    let (mut builder, mut tcap) = create_silver_currency(otw, ctx);
 
-    transfer::public_freeze_object(metadata);
-
-    // Task Part 1: Mint the total supply, and transfer it to sender.
-    // Lock the treasury cap inside the freezer as DOF so that it is unusable
-    // but still easily indexable, and lastly freeze Freezer.
+    // Task: Mint the total supply and transfer to sender.
+    // Then lock the supply as fixed using builder.make_supply_fixed(tcap)
+    // which consumes the TreasuryCap, preventing further minting or burning.
+    // Finally, finalize the builder and transfer the metadata_cap to sender.
     todo!<()>()
 }
 
 fun create_silver_currency(
     otw: SILVER,
-    ctx: &mut TxContext
-): (TreasuryCap<SILVER>, CoinMetadata<SILVER>) {
-    coin::create_currency<SILVER>(
+    ctx: &mut TxContext,
+): (coin_registry::CurrencyInitializer<SILVER>, TreasuryCap<SILVER>) {
+    coin_registry::new_currency_with_otw(
         otw,
         DECIMALS,
-        SYMBOL,
-        NAME,
-        DESCRIPTION,
-        option::some(url::new_unsafe_from_bytes(ICON_URL)),
-        ctx
+        SYMBOL.to_string(),
+        NAME.to_string(),
+        DESCRIPTION.to_string(),
+        ICON_URL.to_string(),
+        ctx,
     )
 }
 
-macro fun todo<$T>(): $T {
+public macro fun todo<$T>(): $T {
     abort(ETodo)
 }
 
 #[test_only]
-use sui::{coin::Coin, dynamic_object_field as dof, test_scenario};
+use std::unit_test;
 
 #[test]
 fun test_init() {
     let publisher = @0x11111;
 
-    let mut scenario = test_scenario::begin(publisher);
-    init(SILVER(), scenario.ctx());
+    let mut scenario = sui::test_scenario::begin(publisher);
+    init(SILVER {}, scenario.ctx());
     scenario.next_tx(publisher);
     {
-        let freezer = scenario.take_immutable<Freezer>();
-        assert!(dof::exists_(&freezer.id, TreasuryCapKey()));
-        let cap: &TreasuryCap<SILVER> = dof::borrow(&freezer.id, TreasuryCapKey());
-        assert!(cap.total_supply() == TOTAL_SUPPLY);
-
-        let coin = scenario.take_from_sender<Coin<SILVER>>();
+        let coin = scenario.take_from_sender<sui::coin::Coin<SILVER>>();
         assert!(coin.value() == TOTAL_SUPPLY);
         scenario.return_to_sender(coin);
-        test_scenario::return_immutable(freezer);
+
+        let metadata_cap = scenario.take_from_sender<coin_registry::MetadataCap<SILVER>>();
+        unit_test::destroy(metadata_cap);
     };
     scenario.end();
 }
-

--- a/I2/fixed_supply/sources/silver.move
+++ b/I2/fixed_supply/sources/silver.move
@@ -18,10 +18,12 @@ const TOTAL_SUPPLY: u64 = 10_000_000_000_000_000_000;
 fun init(otw: SILVER, ctx: &mut TxContext) {
     let (mut builder, mut tcap) = create_silver_currency(otw, ctx);
 
-    // Task: Mint the total supply and transfer to sender.
-    // Then lock the supply as fixed using builder.make_supply_fixed(tcap)
-    // which consumes the TreasuryCap, preventing further minting or burning.
-    // Finally, finalize the builder and transfer the metadata_cap to sender.
+    // Task: Complete the init function:
+    // 1. Mint the total supply using tcap.mint(TOTAL_SUPPLY, ctx)
+    // 2. Transfer the minted coin to the sender
+    // 3. Lock the supply as fixed using builder.make_supply_fixed(tcap)
+    //    Note: This consumes the TreasuryCap - once called, no more minting or burning is possible
+    // 4. Finalize the builder and transfer the metadata_cap to sender
     todo!<()>()
 }
 
@@ -40,7 +42,7 @@ fun create_silver_currency(
     )
 }
 
-public macro fun todo<$T>(): $T {
+macro fun todo<$T>(): $T {
     abort(ETodo)
 }
 

--- a/I3/king_credits/sources/crown_council_rule.move
+++ b/I3/king_credits/sources/crown_council_rule.move
@@ -78,12 +78,12 @@ fun test_edit_council() {
     add_council_member(&mut policy, &cap, council_member_2);
     let config: &Config = token::rule_config(CrownCouncilRule(), &policy);
     assert!(config.members.contains(&council_member_2));
-    assert!(config.members.size() == 2);
+    assert!(config.members.length() == 2);
 
     remove_council_member(&mut policy, &cap, council_member_1);
     let config: &Config = token::rule_config(CrownCouncilRule(), &policy);
     assert!(!config.members.contains(&council_member_1));
-    assert!(config.members.size() == 1);
+    assert!(config.members.length() == 1);
     policy.burn_policy_for_testing(cap);
 }
 

--- a/I3/king_credits/sources/crown_council_rule.move
+++ b/I3/king_credits/sources/crown_council_rule.move
@@ -25,6 +25,7 @@ public fun add_rule_config<T>(
     ctx: &mut TxContext,
 ) {
     // Task: Setup rule config for CrownCouncilRule. It will initialize with `initial_members`.
+    // Use token::add_rule_config to register Config{members: vec_set::from_keys(initial_members)}
     assert!(initial_members.length() <= MAX_CROWN_COUNCIL_MEMBERS, EMaxCouncilMembers);
     todo!()
 }

--- a/I3/king_credits/sources/king_credits.move
+++ b/I3/king_credits/sources/king_credits.move
@@ -27,10 +27,12 @@ fun init(otw: KING_CREDITS, ctx: &mut TxContext) {
         ctx,
     );
 
-    // Task: Create a token policy from the TreasuryCap, add CrownCouncilRule
-    // for the transfer action, setup the rule config with an empty initial
-    // members list, finalize the builder, then share the policy and transfer
-    // the policy_cap, tcap, and metadata_cap to sender.
+    // Task: Complete the init function:
+    // 1. Create a token policy from the TreasuryCap using token::new_policy(&tcap, ctx)
+    // 2. Add CrownCouncilRule for the transfer action using token::add_rule_for_action
+    // 3. Setup the rule config with an empty initial members list using crown_council_rule::add_rule_config
+    // 4. Finalize the builder to get the metadata_cap
+    // 5. Share the policy and transfer policy_cap, tcap, and metadata_cap to sender
     abort(ETodo)
 }
 

--- a/I3/king_credits/sources/king_credits.move
+++ b/I3/king_credits/sources/king_credits.move
@@ -1,9 +1,8 @@
 /// Module: king_credits
 module king_credits::king_credits;
 
-use sui::coin;
+use sui::coin_registry;
 use sui::token;
-use sui::url;
 
 use king_credits::crown_council_rule::{Self, CrownCouncilRule};
 
@@ -15,21 +14,23 @@ const SYMBOL: vector<u8> = b"KING_CREDITS";
 const DESCRIPTION: vector<u8> = b"Awarded to citizens for heroic actions.";
 const ICON_URL: vector<u8> = b"https://aggregator.walrus-testnet.walrus.space/v1/blobs/uh8f-t66vVmQLtZEhO024rvHOVskOrLq_Wb2BHJRKBw";
 
-public struct KING_CREDITS() has drop;
+public struct KING_CREDITS has drop {}
 
 fun init(otw: KING_CREDITS, ctx: &mut TxContext) {
-    let (tcap, metadata) = coin::create_currency(
+    let (builder, tcap) = coin_registry::new_currency_with_otw(
         otw,
         DECIMALS,
-        SYMBOL,
-        NAME,
-        DESCRIPTION,
-        option::some(url::new_unsafe_from_bytes(ICON_URL)),
-        ctx
+        SYMBOL.to_string(),
+        NAME.to_string(),
+        DESCRIPTION.to_string(),
+        ICON_URL.to_string(),
+        ctx,
     );
 
-    // Task: Create policy, allow transfer with CrownCouncilRule and setup its
-    // config.
+    // Task: Create a token policy from the TreasuryCap, add CrownCouncilRule
+    // for the transfer action, setup the rule config with an empty initial
+    // members list, finalize the builder, then share the policy and transfer
+    // the policy_cap, tcap, and metadata_cap to sender.
     abort(ETodo)
 }
 
@@ -49,7 +50,7 @@ fun test_transfer() {
     let mut scenario = test_scenario::begin(publisher);
     // Initialize package
     {
-        init(KING_CREDITS(), scenario.ctx());
+        init(KING_CREDITS {}, scenario.ctx());
     };
 
     // Edit Policy rules


### PR DESCRIPTION
## Summary

Updates I1, I2, I3 coin exercises to use the new `coin_registry` standard while maintaining the scaffolded TODO structure for learners.

* Update imports to `sui::coin_registry`
* Maintain `todo!()` macros with clear task comments
* Add scaffolded tests demonstrating expected behavior

## Changes

* `I1/silver`: Create currency and mint functions scaffolded
* `I2/fixed_supply`: Fixed supply pattern with coin_registry
* `I3/king_credits`: Multi-sig treasury with coin_registry

Companion to MystenLabs/sui-move-bootcamp#176 (solution branch)

Part of [SBG-256](https://linear.app/mysten-labs/issue/SBG-256/digital-assets-review-examples)

🤖 Generated with [Claude Code](<https://claude.ai/code>)